### PR TITLE
sync: 将 main 分支 v1.1.8 更新移植到 rust-main 分支

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>1.1.7</Version>
+    <Version>1.1.8</Version>
   </PropertyGroup>
 </Project>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">WitchDrawer</h1>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-1.1.7-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/version-1.1.8-blue" alt="Version" />
   <img src="https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-green" alt="License" />
   <img src="https://img.shields.io/badge/.NET-10.0-purple" alt=".NET" />
   <img src="https://img.shields.io/badge/platform-Windows-blue" alt="Platform" />

--- a/installer/WitchDrawer.iss
+++ b/installer/WitchDrawer.iss
@@ -3,7 +3,7 @@
 ; Produces a Windows installer (-Setup.exe) alongside the portable zip.
 ;
 ; Preprocessor vars:
-;   MyAppVersion   — passed via /DMyAppVersion=1.1.7 (matches Directory.Build.props)
+;   MyAppVersion   — passed via /DMyAppVersion=1.1.8 (matches Directory.Build.props)
 ;   PublishDir     — the dotnet publish output folder containing WitchDrawer.App.exe
 ;
 ; NOTE: Only the main exe + pdbs ship in the installer; the app is a
@@ -16,11 +16,11 @@
 ; updater.bat handles it via xcopy with /y).
 
 #ifndef MyAppVersion
-  #define MyAppVersion "1.1.7"
+  #define MyAppVersion "1.1.8"
 #endif
 
 #ifndef PublishDir
-  #define PublishDir "..\publish\v1.1.7"
+  #define PublishDir "..\publish\v1.1.8"
 #endif
 
 #define MyAppName "WitchDrawer"

--- a/src/WitchDrawer.App/App.xaml
+++ b/src/WitchDrawer.App/App.xaml
@@ -7,6 +7,7 @@
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
         <infra:InverseBooleanToVisibilityConverter x:Key="InverseBooleanToVisibilityConverter" />
         <infra:NonEmptyToVisibilityConverter x:Key="NonEmptyToVisibilityConverter" />
+        <infra:BoxVisualStyleEqualityConverter x:Key="BoxVisualStyleEqualityConverter" />
 
         <Color x:Key="AppBackgroundColor">#F4F6F8</Color>
         <Color x:Key="PanelColor">#FFFFFF</Color>
@@ -36,6 +37,7 @@
         <SolidColorBrush x:Key="CardShadowBrush" Color="#121D1D1F" />
         <SolidColorBrush x:Key="DropZoneBrush" Color="#FAFAFC" />
         <SolidColorBrush x:Key="WindowOverlayBrush" Color="#00FFFFFF" />
+        <SolidColorBrush x:Key="ControlCenterSurfaceBrush" Color="#F5F8FC" />
 
         <Style TargetType="{x:Type Button}">
             <Setter Property="Background" Value="{DynamicResource PanelBrush}" />
@@ -168,6 +170,79 @@
                             <Trigger Property="Orientation" Value="Horizontal">
                                 <Setter Property="Width" Value="Auto" />
                                 <Setter Property="Height" Value="8" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="DrawerScrollBarStyle" TargetType="{x:Type ScrollBar}">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Width" Value="12" />
+            <Setter Property="MinWidth" Value="12" />
+            <Setter Property="Focusable" Value="False" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type ScrollBar}">
+                        <Grid Width="{TemplateBinding Width}"
+                              Background="Transparent">
+                            <Border x:Name="TrackRail"
+                                    Width="6"
+                                    Margin="0,5"
+                                    HorizontalAlignment="Center"
+                                    Background="{DynamicResource BorderBrushSoft}"
+                                    CornerRadius="3"
+                                    Opacity="0.52" />
+                            <Track x:Name="PART_Track"
+                                   Margin="0,5"
+                                   IsDirectionReversed="True"
+                                   Focusable="False">
+                                <Track.DecreaseRepeatButton>
+                                    <RepeatButton Command="{x:Static ScrollBar.PageUpCommand}"
+                                                  Focusable="False"
+                                                  Opacity="0" />
+                                </Track.DecreaseRepeatButton>
+                                <Track.Thumb>
+                                    <Thumb MinHeight="34"
+                                           Cursor="Hand"
+                                           Focusable="False">
+                                        <Thumb.Template>
+                                            <ControlTemplate TargetType="{x:Type Thumb}">
+                                                <Grid Width="12">
+                                                    <Border x:Name="ThumbSurface"
+                                                            Width="6"
+                                                            HorizontalAlignment="Center"
+                                                            Background="{DynamicResource AccentBrush}"
+                                                            CornerRadius="3"
+                                                            Opacity="0.62" />
+                                                </Grid>
+                                                <ControlTemplate.Triggers>
+                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                        <Setter TargetName="ThumbSurface" Property="Width" Value="8" />
+                                                        <Setter TargetName="ThumbSurface" Property="CornerRadius" Value="4" />
+                                                        <Setter TargetName="ThumbSurface" Property="Opacity" Value="0.86" />
+                                                    </Trigger>
+                                                    <Trigger Property="IsDragging" Value="True">
+                                                        <Setter TargetName="ThumbSurface" Property="Width" Value="8" />
+                                                        <Setter TargetName="ThumbSurface" Property="CornerRadius" Value="4" />
+                                                        <Setter TargetName="ThumbSurface" Property="Opacity" Value="1" />
+                                                    </Trigger>
+                                                </ControlTemplate.Triggers>
+                                            </ControlTemplate>
+                                        </Thumb.Template>
+                                    </Thumb>
+                                </Track.Thumb>
+                                <Track.IncreaseRepeatButton>
+                                    <RepeatButton Command="{x:Static ScrollBar.PageDownCommand}"
+                                                  Focusable="False"
+                                                  Opacity="0" />
+                                </Track.IncreaseRepeatButton>
+                            </Track>
+                        </Grid>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="TrackRail" Property="Opacity" Value="0.72" />
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>

--- a/src/WitchDrawer.App/App.xaml.cs
+++ b/src/WitchDrawer.App/App.xaml.cs
@@ -76,6 +76,9 @@ public partial class App : Application
             var todoService = new RustTodoService(drawerService);
             var updateService = new RustUpdateService(drawerService, logger);
             var quickPanelHotKeySettings = new QuickPanelHotKeySettingsStore(drawerService);
+            var boxVisualStyleStore = new BoxVisualStyleStore(drawerService, logger);
+            var boxPositionLockStateStore =
+                new BoxPositionLockStateStore(drawerService, logger);
 
             logger.Info("Data directory: " + paths.RootDirectory);
             logger.Info("Database path: " + paths.DatabasePath);
@@ -85,7 +88,11 @@ public partial class App : Application
                 quickPanelHotKeySettings);
             AppThemeManager.Apply(await LoadSavedThemeAsync(drawerService));
 
-            var quickPanelViewModel = new QuickPanelViewModel(drawerService, launcher, logger);
+            var quickPanelViewModel = new QuickPanelViewModel(
+                drawerService,
+                launcher,
+                logger,
+                boxVisualStyleStore);
             var quickPanel = new QuickPanelWindow(quickPanelViewModel);
             var mainViewModel = new MainViewModel(
                 drawerService,
@@ -93,12 +100,16 @@ public partial class App : Application
                 launcher,
                 logger,
                 quickPanelViewModel,
-                updateService);
+                updateService,
+                boxVisualStyleStore,
+                boxPositionLockStateStore);
             _desktopBoxManager = new DesktopBoxManager(
                 drawerService,
                 todoService,
                 launcher,
-                logger);
+                logger,
+                boxVisualStyleStore,
+                boxPositionLockStateStore);
             _mainWindow = new MainWindow(
                 mainViewModel,
                 quickPanel,

--- a/src/WitchDrawer.App/Infrastructure/AppThemeManager.cs
+++ b/src/WitchDrawer.App/Infrastructure/AppThemeManager.cs
@@ -46,6 +46,7 @@ public static class AppThemeManager
 
         if (theme == AppTheme.Glass)
         {
+            SetColor("ControlCenterSurfaceBrush", "#F20D0D16"); // Stable dark control-center surface
             SetColor("AppBackgroundBrush", "#E60D0D16"); // Deep obsidian dark translucent
             SetColor("PanelBrush", "#CC1A1A24");         // Dark card/panel background
             SetColor("PanelAltBrush", "#9914141E");      // Deep sidebar/control background
@@ -68,6 +69,7 @@ public static class AppThemeManager
         }
         else if (theme == AppTheme.Crystal)
         {
+            SetColor("ControlCenterSurfaceBrush", "#EDF3F8FC"); // Quiet readable surface over wallpapers
             SetColor("AppBackgroundBrush", "#B8F3F8FC");  // Readable crystal veil over wallpapers
             SetColor("PanelBrush", "#B8FFFFFF");          // Stable content surface
             SetColor("PanelAltBrush", "#94F7FAFC");       // Distinct but lightweight sidebar
@@ -90,6 +92,7 @@ public static class AppThemeManager
         }
         else
         {
+            SetColor("ControlCenterSurfaceBrush", "#FFF5F8FC"); // Native cool-white workspace
             SetColor("AppBackgroundBrush", "#F3F4F6");    // Clean soft light background
             SetColor("PanelBrush", "#FFFFFF");            // White card/panel background
             SetColor("PanelAltBrush", "#F9FAFB");         // Light gray sidebar background

--- a/src/WitchDrawer.App/Infrastructure/BoxPositionLockStateStore.cs
+++ b/src/WitchDrawer.App/Infrastructure/BoxPositionLockStateStore.cs
@@ -1,0 +1,86 @@
+using System.Collections.Concurrent;
+using WitchDrawer.Core.Logging;
+using WitchDrawer.Core.Services;
+
+namespace WitchDrawer.App.Infrastructure;
+
+public sealed class BoxPositionLockStateStore(
+    DrawerService drawerService,
+    IAppLogger logger)
+{
+    private const string SettingKeyPrefix = "BoxPositionLocked:";
+    private readonly ConcurrentDictionary<Guid, bool> _cache = new();
+
+    public async Task<bool> LoadAsync(
+        Guid boxId,
+        CancellationToken cancellationToken = default)
+    {
+        if (_cache.TryGetValue(boxId, out var cachedState))
+        {
+            return cachedState;
+        }
+
+        string? savedValue;
+        try
+        {
+            savedValue = await drawerService.GetSettingAsync(
+                GetSettingKey(boxId),
+                cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            logger.Error(
+                exception,
+                $"Failed to load position lock state for box {boxId:N}.");
+            throw;
+        }
+
+        if (string.IsNullOrWhiteSpace(savedValue))
+        {
+            _cache[boxId] = false;
+            return false;
+        }
+
+        if (bool.TryParse(savedValue, out var isPositionLocked))
+        {
+            _cache[boxId] = isPositionLocked;
+            return isPositionLocked;
+        }
+
+        logger.Error(
+            new FormatException($"Unsupported position lock state value: {savedValue}"),
+            $"Ignored invalid position lock state for box {boxId:N}; using false.");
+        _cache[boxId] = false;
+        return false;
+    }
+
+    public async Task SaveAsync(
+        Guid boxId,
+        bool isPositionLocked,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await drawerService.SetSettingAsync(
+                GetSettingKey(boxId),
+                isPositionLocked.ToString(),
+                cancellationToken);
+            _cache[boxId] = isPositionLocked;
+            logger.Info(
+                $"Saved position lock state {isPositionLocked} for box {boxId:N}.");
+        }
+        catch (Exception exception)
+        {
+            logger.Error(
+                exception,
+                $"Failed to save position lock state {isPositionLocked} "
+                + $"for box {boxId:N}.");
+            throw;
+        }
+    }
+
+    internal static string GetSettingKey(Guid boxId)
+    {
+        return SettingKeyPrefix + boxId.ToString("N");
+    }
+}

--- a/src/WitchDrawer.App/Infrastructure/BoxPositionLockStateStore.cs
+++ b/src/WitchDrawer.App/Infrastructure/BoxPositionLockStateStore.cs
@@ -1,11 +1,11 @@
 using System.Collections.Concurrent;
+using WitchDrawer.Core.Abstractions;
 using WitchDrawer.Core.Logging;
-using WitchDrawer.Core.Services;
 
 namespace WitchDrawer.App.Infrastructure;
 
 public sealed class BoxPositionLockStateStore(
-    DrawerService drawerService,
+    IDrawerService drawerService,
     IAppLogger logger)
 {
     private const string SettingKeyPrefix = "BoxPositionLocked:";

--- a/src/WitchDrawer.App/Infrastructure/BoxVisualStyleEqualityConverter.cs
+++ b/src/WitchDrawer.App/Infrastructure/BoxVisualStyleEqualityConverter.cs
@@ -1,0 +1,29 @@
+using System.Globalization;
+using System.Windows.Data;
+using WitchDrawer.App.ViewModels;
+
+namespace WitchDrawer.App.Infrastructure;
+
+public sealed class BoxVisualStyleEqualityConverter : IMultiValueConverter
+{
+    public object Convert(
+        object[] values,
+        Type targetType,
+        object parameter,
+        CultureInfo culture)
+    {
+        return values.Length >= 2
+            && values[0] is BoxVisualStyle optionStyle
+            && values[1] is BoxVisualStyle selectedStyle
+            && optionStyle == selectedStyle;
+    }
+
+    public object[] ConvertBack(
+        object value,
+        Type[] targetTypes,
+        object parameter,
+        CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/src/WitchDrawer.App/Infrastructure/BoxVisualStyleStore.cs
+++ b/src/WitchDrawer.App/Infrastructure/BoxVisualStyleStore.cs
@@ -1,0 +1,109 @@
+using System.Collections.Concurrent;
+using WitchDrawer.App.ViewModels;
+using WitchDrawer.Core.Logging;
+using WitchDrawer.Core.Models;
+using WitchDrawer.Core.Services;
+
+namespace WitchDrawer.App.Infrastructure;
+
+public sealed class BoxVisualStyleStore(
+    DrawerService drawerService,
+    IAppLogger logger)
+{
+    private const string SettingKeyPrefix = "BoxVisualStyle:";
+    private readonly ConcurrentDictionary<Guid, BoxVisualStyle> _cache = new();
+
+    public async Task<BoxVisualStyle> LoadAsync(
+        Box box,
+        CancellationToken cancellationToken = default)
+    {
+        if (box.Type is not BoxType.Normal and not BoxType.Pixel)
+        {
+            _cache[box.Id] = BoxVisualStyle.Modern;
+            return BoxVisualStyle.Modern;
+        }
+
+        if (_cache.TryGetValue(box.Id, out var cachedStyle))
+        {
+            return cachedStyle;
+        }
+
+        var fallback = GetLegacyCompatibleFallback(box);
+        string? savedValue;
+        try
+        {
+            savedValue = await drawerService.GetSettingAsync(
+                GetSettingKey(box.Id),
+                cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            logger.Error(
+                exception,
+                $"Failed to load visual style for box {box.Id:N}.");
+            throw;
+        }
+
+        if (string.IsNullOrWhiteSpace(savedValue))
+        {
+            _cache[box.Id] = fallback;
+            return fallback;
+        }
+
+        if (Enum.TryParse<BoxVisualStyle>(savedValue, ignoreCase: true, out var parsedStyle)
+            && BoxVisualStyleCatalog.IsSupported(parsedStyle))
+        {
+            _cache[box.Id] = parsedStyle;
+            return parsedStyle;
+        }
+
+        logger.Error(
+            new FormatException($"Unsupported box visual style value: {savedValue}"),
+            $"Ignored invalid visual style for box {box.Id:N}; using {fallback}.");
+        _cache[box.Id] = fallback;
+        return fallback;
+    }
+
+    public async Task SaveAsync(
+        Guid boxId,
+        BoxVisualStyle style,
+        CancellationToken cancellationToken = default)
+    {
+        if (!BoxVisualStyleCatalog.IsSupported(style))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(style),
+                style,
+                "Unsupported box visual style.");
+        }
+
+        try
+        {
+            await drawerService.SetSettingAsync(
+                GetSettingKey(boxId),
+                style.ToString(),
+                cancellationToken);
+            _cache[boxId] = style;
+            logger.Info($"Saved visual style {style} for box {boxId:N}.");
+        }
+        catch (Exception exception)
+        {
+            logger.Error(
+                exception,
+                $"Failed to save visual style {style} for box {boxId:N}.");
+            throw;
+        }
+    }
+
+    internal static string GetSettingKey(Guid boxId)
+    {
+        return SettingKeyPrefix + boxId.ToString("N");
+    }
+
+    private static BoxVisualStyle GetLegacyCompatibleFallback(Box box)
+    {
+        return box.Type == BoxType.Pixel
+            ? BoxVisualStyle.Pixel
+            : BoxVisualStyle.Modern;
+    }
+}

--- a/src/WitchDrawer.App/Infrastructure/BoxVisualStyleStore.cs
+++ b/src/WitchDrawer.App/Infrastructure/BoxVisualStyleStore.cs
@@ -1,13 +1,13 @@
 using System.Collections.Concurrent;
 using WitchDrawer.App.ViewModels;
+using WitchDrawer.Core.Abstractions;
 using WitchDrawer.Core.Logging;
 using WitchDrawer.Core.Models;
-using WitchDrawer.Core.Services;
 
 namespace WitchDrawer.App.Infrastructure;
 
 public sealed class BoxVisualStyleStore(
-    DrawerService drawerService,
+    IDrawerService drawerService,
     IAppLogger logger)
 {
     private const string SettingKeyPrefix = "BoxVisualStyle:";

--- a/src/WitchDrawer.App/Infrastructure/DesktopBoxManager.cs
+++ b/src/WitchDrawer.App/Infrastructure/DesktopBoxManager.cs
@@ -20,6 +20,8 @@ public sealed class DesktopBoxManager
     private readonly ITodoService _todoService;
     private readonly IFileLauncher _launcher;
     private readonly IAppLogger _logger;
+    private readonly BoxVisualStyleStore _boxVisualStyleStore;
+    private readonly BoxPositionLockStateStore _boxPositionLockStateStore;
     private readonly Dictionary<Guid, DesktopBoxWindow> _windows = [];
     private readonly ForegroundWindowMonitor _foregroundWindowMonitor;
     private bool _closing;
@@ -33,12 +35,16 @@ public sealed class DesktopBoxManager
         IDrawerService drawerService,
         ITodoService todoService,
         IFileLauncher launcher,
-        IAppLogger logger)
+        IAppLogger logger,
+        BoxVisualStyleStore boxVisualStyleStore,
+        BoxPositionLockStateStore boxPositionLockStateStore)
     {
         _drawerService = drawerService;
         _todoService = todoService;
         _launcher = launcher;
         _logger = logger;
+        _boxVisualStyleStore = boxVisualStyleStore;
+        _boxPositionLockStateStore = boxPositionLockStateStore;
         _foregroundWindowMonitor = new ForegroundWindowMonitor();
         _foregroundWindowMonitor.ForegroundWindowChanged += OnForegroundWindowChanged;
         _desktopIsForeground = ForegroundWindowMonitor.IsDesktopWindow(
@@ -51,6 +57,9 @@ public sealed class DesktopBoxManager
         WeakReferenceMessenger.Default.Register<DesktopBoxManager, BoxLayoutPresetChangedMessage>(
             this,
             static (recipient, message) => recipient.ApplyBoxLayoutPreset(message));
+        WeakReferenceMessenger.Default.Register<DesktopBoxManager, BoxPositionLockStateChangedMessage>(
+            this,
+            static (recipient, message) => recipient.ApplyBoxPositionLockState(message));
     }
 
     public event EventHandler? ItemsChanged;
@@ -99,6 +108,9 @@ public sealed class DesktopBoxManager
                 }
 
                 var box = boxes[index];
+                var visualStyle = await _boxVisualStyleStore.LoadAsync(box);
+                var isPositionLocked =
+                    await _boxPositionLockStateStore.LoadAsync(box.Id);
                 if (!_windows.TryGetValue(box.Id, out var window))
                 {
                     var layoutSettings = new DesktopBoxLayoutSettings();
@@ -112,6 +124,7 @@ public sealed class DesktopBoxManager
                         _todoService,
                         _launcher,
                         _logger,
+                        visualStyle,
                         layoutSettings);
                     viewModel.ItemsChanged += (_, _) => ItemsChanged?.Invoke(this, EventArgs.Empty);
 
@@ -137,12 +150,14 @@ public sealed class DesktopBoxManager
                     });
 
                     window.Show();
+                    window.SetPositionLocked(isPositionLocked);
                     window.SetDesktopForeground(_desktopIsForeground);
                     window.QueueSendToBottom();
                 }
                 else
                 {
-                    window.ViewModel.UpdateBox(box);
+                    window.ViewModel.UpdateBox(box, visualStyle);
+                    window.SetPositionLocked(isPositionLocked);
                 }
 
                 await window.ViewModel.LoadAsync();
@@ -405,6 +420,20 @@ public sealed class DesktopBoxManager
         }
 
         window.ViewModel.LayoutSettings.ApplyPresetWithoutCallback(message.Preset);
+    }
+
+    private void ApplyBoxPositionLockState(
+        BoxPositionLockStateChangedMessage message)
+    {
+        if (!_windows.TryGetValue(message.BoxId, out var window))
+        {
+            return;
+        }
+
+        window.SetPositionLocked(message.IsPositionLocked);
+        _logger.Info(
+            $"Applied position lock state {message.IsPositionLocked} "
+            + $"to desktop box {message.BoxId:N}.");
     }
 
     private async Task PlaceWindowAsync(Window window, Guid boxId, int fallbackIndex)

--- a/src/WitchDrawer.App/MainWindow.xaml
+++ b/src/WitchDrawer.App/MainWindow.xaml
@@ -1,6 +1,7 @@
 <Window x:Class="WitchDrawer.App.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:views="clr-namespace:WitchDrawer.App.Views"
         Title="WitchDrawer"
         Icon="/Assets/app.png"
         Width="920"
@@ -775,7 +776,8 @@
                                         BorderBrush="{DynamicResource BorderBrushSoft}"
                                         BorderThickness="1"
                                         CornerRadius="8"
-                                        Padding="9,5">
+                                        Padding="9,5"
+                                        Visibility="{Binding IsSelectedTodoBox, Converter={StaticResource InverseBooleanToVisibilityConverter}}">
                                     <StackPanel Orientation="Horizontal">
                                         <Path Data="M 2,1 L 9,1 L 13,5 L 13,14 L 2,14 Z M 9,1 L 9,5 L 13,5" 
                                               Stroke="{DynamicResource TextMutedBrush}" StrokeThickness="1.2" Width="11" Height="12" VerticalAlignment="Center" Margin="0,0,6,0" />
@@ -783,10 +785,39 @@
                                                    Foreground="{DynamicResource TextMutedBrush}" FontSize="11" FontWeight="SemiBold" />
                                     </StackPanel>
                                 </Border>
+                                <Border Background="{DynamicResource PanelBrush}"
+                                        BorderBrush="{DynamicResource BorderBrushSoft}"
+                                        BorderThickness="1"
+                                        CornerRadius="8"
+                                        Padding="9,5"
+                                        Visibility="{Binding IsSelectedTodoBox, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="&#xE8FD;"
+                                                   FontFamily="Segoe Fluent Icons"
+                                                   Foreground="{DynamicResource TextMutedBrush}"
+                                                   FontSize="11"
+                                                   VerticalAlignment="Center"
+                                                   Margin="0,0,6,0" />
+                                        <TextBlock Text="{Binding TodoBoxDetail.RemainingCount, StringFormat=剩余 {0} 项}"
+                                                   Foreground="{DynamicResource TextMutedBrush}"
+                                                   FontSize="11"
+                                                   FontWeight="SemiBold" />
+                                    </StackPanel>
+                                </Border>
                             </StackPanel>
                         </Grid>
 
                         <Grid Grid.Row="1" VerticalAlignment="Stretch">
+                            <Grid.Style>
+                                <Style TargetType="{x:Type Grid}">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsSelectedTodoBox}" Value="True">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Grid.Style>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="*" />
@@ -1544,6 +1575,12 @@
                                 </Grid>
                             </Border>
                          </Grid>
+
+                        <views:TodoBoxDetailView Grid.Row="1"
+                                                 DataContext="{Binding TodoBoxDetail}"
+                                                 Visibility="{Binding DataContext.IsSelectedTodoBox,
+                                                                      RelativeSource={RelativeSource AncestorType={x:Type Window}},
+                                                                      Converter={StaticResource BooleanToVisibilityConverter}}" />
                      </Grid>
 
                     <!-- Todo Archive Page -->

--- a/src/WitchDrawer.App/MainWindow.xaml
+++ b/src/WitchDrawer.App/MainWindow.xaml
@@ -7,6 +7,7 @@
         Height="560"
         MinWidth="920"
         MinHeight="560"
+        FontFamily="Microsoft YaHei UI"
         WindowStyle="None"
         AllowsTransparency="True"
         ResizeMode="NoResize"
@@ -17,12 +18,12 @@
         Drop="OnFilesDropped"
         PreviewDragOver="OnPreviewDragOver">
     <Border Margin="12"
-            Background="{DynamicResource AppBackgroundBrush}"
+            Background="{DynamicResource ControlCenterSurfaceBrush}"
             BorderBrush="{DynamicResource BorderBrushSoft}"
             BorderThickness="1"
-            CornerRadius="24">
+            CornerRadius="20">
         <Border.Effect>
-            <DropShadowEffect BlurRadius="18" Color="#000000" Opacity="0.18" ShadowDepth="2" Direction="270" />
+            <DropShadowEffect BlurRadius="20" Color="#162335" Opacity="0.16" ShadowDepth="3" Direction="270" />
         </Border.Effect>
         <Grid>
             <Grid.RowDefinitions>
@@ -34,7 +35,7 @@
                     Background="{DynamicResource PanelAltBrush}"
                     BorderBrush="{DynamicResource BorderBrushSoft}"
                     BorderThickness="0,0,0,1"
-                    CornerRadius="24,24,0,0"
+                    CornerRadius="20,20,0,0"
                     IsHitTestVisible="False" />
 
             <!-- Top Header & Custom Window Chrome -->
@@ -45,83 +46,81 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="22,0,0,0">
-                    <Border Width="28" Height="28" CornerRadius="8" ClipToBounds="True" Background="Transparent">
-                        <Image Source="/Assets/app.png" RenderOptions.BitmapScalingMode="HighQuality" Width="28" Height="28" />
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="20,0,0,0">
+                    <Border Width="30" Height="30" CornerRadius="9" ClipToBounds="True" Background="Transparent">
+                        <Image Source="/Assets/app.png" RenderOptions.BitmapScalingMode="HighQuality" Width="30" Height="30" />
                     </Border>
                     <TextBlock Text="WitchDrawer"
                                Margin="10,0,0,0"
                                VerticalAlignment="Center"
                                Foreground="{DynamicResource TextPrimaryBrush}"
-                               FontSize="15"
-                               FontWeight="Bold"
+                               FontSize="14.5"
+                               FontWeight="SemiBold"
                                />
                 </StackPanel>
 
                 <Border Grid.Column="1"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
-                        Background="{DynamicResource PanelBrush}"
-                        BorderBrush="{DynamicResource BorderBrushSoft}"
-                        BorderThickness="1"
-                        CornerRadius="11"
-                        Padding="12,5">
+                        Background="{DynamicResource AccentSoftBrush}"
+                        BorderThickness="0"
+                        CornerRadius="8"
+                        Padding="10,4"
+                        IsHitTestVisible="False">
                     <TextBlock Text="{Binding StatusText}"
-                               Foreground="{DynamicResource TextMutedBrush}"
-                               FontSize="11.5"
+                               Foreground="{DynamicResource AccentBrush}"
+                               FontSize="11"
                                FontWeight="Medium" />
                 </Border>
 
-                <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,22,0">
+                <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,12,0">
                     <Border Background="{DynamicResource PanelBrush}"
                             BorderBrush="{DynamicResource BorderBrushSoft}"
                             BorderThickness="1"
-                            CornerRadius="11"
-                            Padding="10,5"
-                            Margin="0,0,14,0">
+                            CornerRadius="8"
+                            Padding="9,4"
+                            Margin="0,0,8,0">
                         <TextBlock Text="Ctrl+Alt+W"
                                    Foreground="{DynamicResource TextMutedBrush}"
-                                   FontSize="11"
-                                   FontWeight="SemiBold" />
+                                   FontSize="10.5"
+                                   FontWeight="Medium" />
                     </Border>
-                    
-                    <!-- macOS Traffic Light controls -->
-                    <Button Width="13"
-                            Height="13"
+
+                    <Button Width="34"
+                            Height="34"
                             Padding="0"
-                            Background="#FFBD2E"
-                            BorderThickness="0"
+                            Style="{StaticResource GhostButtonStyle}"
                             Click="OnMinimizeClicked"
-                            ToolTip="最小化"
-                            Margin="0,0,8,0">
-                        <Button.Template>
-                            <ControlTemplate TargetType="{x:Type Button}">
-                                <Border x:Name="circle" Background="{TemplateBinding Background}" CornerRadius="6.5" />
-                                <ControlTemplate.Triggers>
-                                    <Trigger Property="IsMouseOver" Value="True">
-                                        <Setter TargetName="circle" Property="Opacity" Value="0.75" />
-                                    </Trigger>
-                                </ControlTemplate.Triggers>
-                            </ControlTemplate>
-                        </Button.Template>
+                            ToolTip="最小化">
+                        <Path Data="M 1,5 L 11,5"
+                              Stroke="{DynamicResource TextMutedBrush}"
+                              StrokeThickness="1.4"
+                              Width="12"
+                              Height="10"
+                              Stretch="Uniform" />
                     </Button>
-                    <Button Width="13"
-                            Height="13"
+                    <Button Width="34"
+                            Height="34"
                             Padding="0"
-                            Background="#FF5F56"
-                            BorderThickness="0"
                             Click="OnCloseClicked"
                             ToolTip="关闭">
-                        <Button.Template>
-                            <ControlTemplate TargetType="{x:Type Button}">
-                                <Border x:Name="circle" Background="{TemplateBinding Background}" CornerRadius="6.5" />
-                                <ControlTemplate.Triggers>
+                        <Button.Style>
+                            <Style TargetType="{x:Type Button}" BasedOn="{StaticResource GhostButtonStyle}">
+                                <Setter Property="Foreground" Value="{DynamicResource TextMutedBrush}" />
+                                <Style.Triggers>
                                     <Trigger Property="IsMouseOver" Value="True">
-                                        <Setter TargetName="circle" Property="Opacity" Value="0.75" />
+                                        <Setter Property="Background" Value="{DynamicResource DangerSoftBrush}" />
+                                        <Setter Property="Foreground" Value="{DynamicResource DangerBrush}" />
                                     </Trigger>
-                                </ControlTemplate.Triggers>
-                            </ControlTemplate>
-                        </Button.Template>
+                                </Style.Triggers>
+                            </Style>
+                        </Button.Style>
+                        <Path Data="M 1,1 L 11,11 M 11,1 L 1,11"
+                              Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                              StrokeThickness="1.4"
+                              Width="12"
+                              Height="12"
+                              Stretch="Uniform" />
                     </Button>
                 </StackPanel>
             </Grid>
@@ -129,7 +128,7 @@
             <!-- Main Panel -->
             <Grid Grid.Row="1" VerticalAlignment="Stretch">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="260" />
+                    <ColumnDefinition Width="226" />
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
@@ -138,8 +137,8 @@
                         Background="{DynamicResource PanelAltBrush}"
                         BorderBrush="{DynamicResource BorderBrushSoft}"
                         BorderThickness="0,1,1,0"
-                        CornerRadius="0,0,0,24"
-                        Padding="18,18,18,22">
+                        CornerRadius="0,0,0,20"
+                        Padding="14,16,14,16">
                     <Grid>
                         <!-- Navigation Tabs Local Resources -->
                         <Grid.Resources>
@@ -147,22 +146,29 @@
                                 <Setter Property="Background" Value="Transparent" />
                                 <Setter Property="Foreground" Value="{DynamicResource TextMutedBrush}" />
                                 <Setter Property="BorderThickness" Value="0" />
-                                <Setter Property="MinHeight" Value="32" />
-                                <Setter Property="Padding" Value="14,6" />
+                                <Setter Property="MinHeight" Value="36" />
+                                <Setter Property="Padding" Value="10,7" />
                                 <Setter Property="Cursor" Value="Hand" />
                                 <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                                 <Setter Property="Template">
                                     <Setter.Value>
                                         <ControlTemplate TargetType="{x:Type Button}">
                                             <Border x:Name="Root"
                                                     Background="{TemplateBinding Background}"
-                                                    CornerRadius="9"
+                                                    BorderBrush="Transparent"
+                                                    BorderThickness="1"
+                                                    CornerRadius="8"
                                                     Padding="{TemplateBinding Padding}">
-                                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                                <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                                  VerticalAlignment="Center" />
                                             </Border>
                                             <ControlTemplate.Triggers>
                                                 <Trigger Property="IsMouseOver" Value="True">
                                                     <Setter TargetName="Root" Property="Opacity" Value="0.9" />
+                                                </Trigger>
+                                                <Trigger Property="IsKeyboardFocused" Value="True">
+                                                    <Setter TargetName="Root" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
                                                 </Trigger>
                                             </ControlTemplate.Triggers>
                                         </ControlTemplate>
@@ -175,21 +181,16 @@
                                     </Trigger>
                                 </Style.Triggers>
                             </Style>
-                            <Style x:Key="NavOverviewButtonStyle" TargetType="{x:Type Button}" BasedOn="{StaticResource NavButtonBaseStyle}">
-                                <Style.Triggers>
-                                    <MultiDataTrigger>
-                                        <MultiDataTrigger.Conditions>
-                                            <Condition Binding="{Binding IsArchivePage}" Value="False" />
-                                            <Condition Binding="{Binding IsSettingsPage}" Value="False" />
-                                            <Condition Binding="{Binding IsAboutPage}" Value="False" />
-                                        </MultiDataTrigger.Conditions>
-                                        <Setter Property="Background" Value="{DynamicResource AccentSoftBrush}" />
-                                        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
-                                        <Setter Property="FontWeight" Value="SemiBold" />
-                                    </MultiDataTrigger>
-                                </Style.Triggers>
+                            <Style x:Key="FooterNavButtonStyle"
+                                   TargetType="{x:Type Button}"
+                                   BasedOn="{StaticResource NavButtonBaseStyle}">
+                                <Setter Property="Height" Value="36" />
+                                <Setter Property="MinHeight" Value="36" />
+                                <Setter Property="Padding" Value="6,4" />
+                                <Setter Property="Margin" Value="1,0" />
+                                <Setter Property="HorizontalContentAlignment" Value="Center" />
                             </Style>
-                            <Style x:Key="NavArchiveButtonStyle" TargetType="{x:Type Button}" BasedOn="{StaticResource NavButtonBaseStyle}">
+                            <Style x:Key="NavArchiveButtonStyle" TargetType="{x:Type Button}" BasedOn="{StaticResource FooterNavButtonStyle}">
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsArchivePage}" Value="True">
                                         <Setter Property="Background" Value="{DynamicResource AccentSoftBrush}" />
@@ -198,7 +199,7 @@
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
-                            <Style x:Key="NavSettingsButtonStyle" TargetType="{x:Type Button}" BasedOn="{StaticResource NavButtonBaseStyle}">
+                            <Style x:Key="NavSettingsButtonStyle" TargetType="{x:Type Button}" BasedOn="{StaticResource FooterNavButtonStyle}">
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsSettingsPage}" Value="True">
                                         <Setter Property="Background" Value="{DynamicResource AccentSoftBrush}" />
@@ -207,7 +208,7 @@
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
-                            <Style x:Key="NavAboutButtonStyle" TargetType="{x:Type Button}" BasedOn="{StaticResource NavButtonBaseStyle}">
+                            <Style x:Key="NavAboutButtonStyle" TargetType="{x:Type Button}" BasedOn="{StaticResource FooterNavButtonStyle}">
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsAboutPage}" Value="True">
                                         <Setter Property="Background" Value="{DynamicResource AccentSoftBrush}" />
@@ -224,41 +225,26 @@
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
 
-                        <StackPanel Grid.Row="0">
-                            <!-- Nav Control -->
-                            <Border Margin="0,0,0,20"
-                                    Padding="3"
-                                    Background="{DynamicResource PanelBrush}"
-                                    BorderBrush="{DynamicResource BorderBrushSoft}"
-                                    BorderThickness="1"
-                                    CornerRadius="12"
-                                    HorizontalAlignment="Stretch">
-                                <UniformGrid Columns="4">
-                                    <Button Content="概览"
-                                            Command="{Binding ShowDashboardCommand}"
-                                            Style="{StaticResource NavOverviewButtonStyle}"
-                                            Margin="0,0,2,0" />
-                                    <Button Content="归档"
-                                            Command="{Binding ShowArchiveCommand}"
-                                            Style="{StaticResource NavArchiveButtonStyle}"
-                                            Margin="0,0,2,0" />
-                                    <Button Content="设置"
-                                            Command="{Binding ShowSettingsCommand}"
-                                            Style="{StaticResource NavSettingsButtonStyle}"
-                                            Margin="0,0,2,0" />
-                                    <Button Content="关于"
-                                            Command="{Binding ShowAboutCommand}"
-                                            Style="{StaticResource NavAboutButtonStyle}" />
-                                </UniformGrid>
-                            </Border>
-
-                            <TextBlock Text="收纳盒列表"
-                                       FontSize="12"
-                                       FontWeight="Bold"
+                        <Grid Grid.Row="0"
+                              Height="30"
+                              Margin="9,0,9,5"
+                              AutomationProperties.Name="收纳盒列表">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="收纳盒"
+                                       FontSize="10.5"
+                                       FontWeight="SemiBold"
                                        Foreground="{DynamicResource TextMutedBrush}"
-                                       Margin="6,0,0,9"
-                                       />
-                        </StackPanel>
+                                       VerticalAlignment="Center" />
+                            <TextBlock Grid.Column="1"
+                                       Text="{Binding Boxes.Count}"
+                                       FontSize="10.5"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextMutedBrush}"
+                                       VerticalAlignment="Center" />
+                        </Grid>
 
                             <ListBox x:Name="BoxesList"
                                      Grid.Row="1"
@@ -268,6 +254,7 @@
                                      SelectionChanged="OnBoxesSelectionChanged"
                                      MouseDoubleClick="OnBoxesMouseDoubleClick"
                                      PreviewMouseLeftButtonDown="OnBoxesPreviewMouseLeftButtonDown"
+                                     PreviewMouseLeftButtonUp="OnBoxesPreviewMouseLeftButtonUp"
                                      PreviewMouseMove="OnBoxesPreviewMouseMove"
                                      DragOver="OnBoxesDragOver"
                                      Drop="OnBoxesDrop"
@@ -276,7 +263,11 @@
                                      ScrollViewer.VerticalScrollBarVisibility="Auto"
                                      VirtualizingPanel.IsVirtualizing="True"
                                      VirtualizingPanel.VirtualizationMode="Recycling"
-                                     Margin="0,0,0,10">
+                                     Margin="0,0,0,6">
+                                <ListBox.Resources>
+                                    <Style TargetType="{x:Type ScrollBar}"
+                                           BasedOn="{StaticResource DrawerScrollBarStyle}" />
+                                </ListBox.Resources>
                                 <ListBox.ItemContainerStyle>
                                     <Style TargetType="{x:Type ListBoxItem}">
                                         <Setter Property="MinHeight" Value="50" />
@@ -353,22 +344,40 @@
                                     <DataTemplate>
                                         <Grid ToolTip="{Binding StorageLabel}">
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="38" />
+                                                <ColumnDefinition Width="36" />
                                                 <ColumnDefinition Width="*" />
                                             </Grid.ColumnDefinitions>
                                             <Border x:Name="BadgeBorder"
-                                                    Width="28"
-                                                    Height="28"
-                                                    CornerRadius="14"
+                                                    Width="29"
+                                                    Height="29"
+                                                    CornerRadius="9"
                                                     Background="{DynamicResource AccentSoftBrush}"
-                                                    BorderBrush="{DynamicResource BorderBrushSoft}"
-                                                    BorderThickness="1">
-                                                <TextBlock Text="{Binding Badge}"
-                                                           Foreground="{DynamicResource AccentBrush}"
-                                                           FontWeight="Bold"
-                                                           FontSize="12.5"
-                                                           HorizontalAlignment="Center"
-                                                           VerticalAlignment="Center" />
+                                                    BorderThickness="0">
+                                                <Grid>
+                                                    <Path x:Name="NormalBoxIcon"
+                                                          Data="M 2,6 L 16,6 L 16,16 L 2,16 Z M 1,2 L 17,2 L 17,7 L 1,7 Z M 7,10 L 11,10"
+                                                          Stroke="{DynamicResource AccentBrush}"
+                                                          StrokeThickness="1.3"
+                                                          Width="15"
+                                                          Height="15"
+                                                          Stretch="Uniform" />
+                                                    <Path x:Name="MappingBoxIcon"
+                                                          Data="M 7,12 L 5.5,13.5 C 4,15 1.5,15 0,13.5 C -1.5,12 -1.5,9.5 0,8 L 3,5 C 4.5,3.5 7,3.5 8.5,5 M 6,9 L 9,6 M 8.5,5 C 10,6.5 10,9 8.5,10.5 L 5.5,13.5 M 9,6 L 10.5,4.5 C 12,3 14.5,3 16,4.5 C 17.5,6 17.5,8.5 16,10 L 13,13 C 11.5,14.5 9,14.5 7.5,13"
+                                                          Stroke="{DynamicResource AccentBrush}"
+                                                          StrokeThickness="1.25"
+                                                          Width="15"
+                                                          Height="15"
+                                                          Stretch="Uniform"
+                                                          Visibility="Collapsed" />
+                                                    <Path x:Name="TodoBoxIcon"
+                                                          Data="M 2,2 L 15,2 L 15,16 L 2,16 Z M 5,9 L 8,12 L 13,6"
+                                                          Stroke="{DynamicResource AccentBrush}"
+                                                          StrokeThickness="1.35"
+                                                          Width="14"
+                                                          Height="14"
+                                                          Stretch="Uniform"
+                                                          Visibility="Collapsed" />
+                                                </Grid>
                                             </Border>
                                             <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="4,0,0,0">
                                                 <TextBlock Text="{Binding Name}"
@@ -384,8 +393,13 @@
                                             </StackPanel>
                                         </Grid>
                                         <DataTemplate.Triggers>
-                                            <DataTrigger Binding="{Binding Type}" Value="Pixel">
-                                                <Setter TargetName="BadgeBorder" Property="CornerRadius" Value="0" />
+                                            <DataTrigger Binding="{Binding Type}" Value="Mapping">
+                                                <Setter TargetName="NormalBoxIcon" Property="Visibility" Value="Collapsed" />
+                                                <Setter TargetName="MappingBoxIcon" Property="Visibility" Value="Visible" />
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding Type}" Value="Todo">
+                                                <Setter TargetName="NormalBoxIcon" Property="Visibility" Value="Collapsed" />
+                                                <Setter TargetName="TodoBoxIcon" Property="Visibility" Value="Visible" />
                                             </DataTrigger>
                                         </DataTemplate.Triggers>
                                     </DataTemplate>
@@ -396,13 +410,14 @@
                             <Button x:Name="BtnCreateBox"
                                     Style="{StaticResource PrimaryButtonStyle}"
                                     Click="OnCreateBoxClicked"
-                                    Margin="0,0,0,10">
+                                    AutomationProperties.Name="新建收纳盒"
+                                    MinHeight="36">
                                 <StackPanel Orientation="Horizontal">
                                     <Path Data="M 0,4 L 8,4 M 4,0 L 4,8" Stroke="White" StrokeThickness="1.5" Width="8" Height="8" VerticalAlignment="Center" Margin="0,0,8,0" SnapsToDevicePixels="True" />
-                                    <TextBlock Text="新建收纳盒..." VerticalAlignment="Center" FontSize="12.5" />
+                                    <TextBlock Text="新建收纳盒" VerticalAlignment="Center" FontSize="12.5" />
                                 </StackPanel>
                             </Button>
-                            
+
                             <!-- 定制级极简纯净菜单悬浮窗 -->
                             <Popup x:Name="CreateBoxPopup"
                                    AllowsTransparency="True"
@@ -420,20 +435,104 @@
                                     <Border.Effect>
                                         <DropShadowEffect BlurRadius="16" ShadowDepth="4" Opacity="0.12" Direction="270" />
                                     </Border.Effect>
-                                    <StackPanel MinWidth="160">
-                                        <Button Content="普通收纳盒" Click="OnCreateNormalBoxClicked" Style="{StaticResource GhostButtonStyle}" Margin="0,0,0,4" Padding="12,10" />
+                                    <StackPanel MinWidth="224">
+                                        <Button Style="{StaticResource GhostButtonStyle}"
+                                                Click="OnCreateNormalBoxClicked"
+                                                Margin="0,0,0,4"
+                                                Padding="12,10"
+                                                HorizontalContentAlignment="Stretch">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto" />
+                                                    <ColumnDefinition Width="*" />
+                                                </Grid.ColumnDefinitions>
+                                                <TextBlock Text="&#xE8B7;"
+                                                           FontFamily="Segoe Fluent Icons"
+                                                           FontSize="14"
+                                                           Foreground="{DynamicResource AccentBrush}"
+                                                           VerticalAlignment="Center" />
+                                                <TextBlock Grid.Column="1"
+                                                           Text="普通收纳盒"
+                                                           Margin="9,0,0,0"
+                                                           Foreground="{DynamicResource TextPrimaryBrush}"
+                                                           FontWeight="SemiBold"
+                                                           VerticalAlignment="Center" />
+                                            </Grid>
+                                        </Button>
                                         <Button Content="映射收纳盒" Click="OnCreateMappingBoxClicked" Style="{StaticResource GhostButtonStyle}" Margin="0,0,0,4" Padding="12,10" />
-                                        <Button Content="像素收纳盒" Click="OnCreatePixelBoxClicked" Style="{StaticResource GhostButtonStyle}" Margin="0,0,0,4" Padding="12,10" />
                                         <Button Content="待办收纳盒" Click="OnCreateTodoBoxClicked" Style="{StaticResource GhostButtonStyle}" Padding="12,10" />
                                     </StackPanel>
                                 </Border>
                             </Popup>
+
+                            <Border Height="1"
+                                    Margin="8,9,8,5"
+                                    Background="{DynamicResource BorderBrushSoft}" />
+
+                            <UniformGrid Columns="3">
+                                <Button Command="{Binding ShowArchiveCommand}"
+                                        Style="{StaticResource NavArchiveButtonStyle}"
+                                        AutomationProperties.Name="归档">
+                                    <StackPanel Orientation="Horizontal">
+                                        <Path Data="M 2,5 L 17,5 L 17,17 L 2,17 Z M 1,2 L 18,2 L 18,6 L 1,6 Z M 7,9 L 12,9"
+                                              Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                              StrokeThickness="1.4"
+                                              Width="14"
+                                              Height="14"
+                                              Stretch="Uniform"
+                                              VerticalAlignment="Center"
+                                              Margin="0,0,5,0" />
+                                        <TextBlock Text="归档"
+                                                   FontSize="11.5"
+                                                   FontWeight="{Binding FontWeight, RelativeSource={RelativeSource AncestorType=Button}}"
+                                                   VerticalAlignment="Center" />
+                                    </StackPanel>
+                                </Button>
+
+                                <Button Command="{Binding ShowSettingsCommand}"
+                                        Style="{StaticResource NavSettingsButtonStyle}"
+                                        AutomationProperties.Name="设置">
+                                    <StackPanel Orientation="Horizontal">
+                                        <Path Data="M 9.5,2 L 11,2.5 L 11.8,5 L 14.2,5.8 L 16.5,4.7 L 17.5,6 L 16,8.2 L 16,10.8 L 17.5,13 L 16.5,14.3 L 14.2,13.2 L 11.8,14 L 11,16.5 L 9.5,17 L 8,16.5 L 7.2,14 L 4.8,13.2 L 2.5,14.3 L 1.5,13 L 3,10.8 L 3,8.2 L 1.5,6 L 2.5,4.7 L 4.8,5.8 L 7.2,5 L 8,2.5 Z M 7,9.5 A 2.5,2.5 0 1 0 12,9.5 A 2.5,2.5 0 1 0 7,9.5"
+                                              Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                              StrokeThickness="1.25"
+                                              Width="14"
+                                              Height="14"
+                                              Stretch="Uniform"
+                                              VerticalAlignment="Center"
+                                              Margin="0,0,5,0" />
+                                        <TextBlock Text="设置"
+                                                   FontSize="11.5"
+                                                   FontWeight="{Binding FontWeight, RelativeSource={RelativeSource AncestorType=Button}}"
+                                                   VerticalAlignment="Center" />
+                                    </StackPanel>
+                                </Button>
+
+                                <Button Command="{Binding ShowAboutCommand}"
+                                        Style="{StaticResource NavAboutButtonStyle}"
+                                        AutomationProperties.Name="关于">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="&#xE946;"
+                                                   Width="15"
+                                                   Margin="0,0,5,0"
+                                                   FontFamily="Segoe Fluent Icons"
+                                                   FontSize="14"
+                                                   Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                                   TextAlignment="Center"
+                                                   VerticalAlignment="Center" />
+                                        <TextBlock Text="关于"
+                                                   FontSize="11.5"
+                                                   FontWeight="{Binding FontWeight, RelativeSource={RelativeSource AncestorType=Button}}"
+                                                   VerticalAlignment="Center" />
+                                    </StackPanel>
+                                </Button>
+                            </UniformGrid>
                         </StackPanel>
                     </Grid>
                 </Border>
 
                 <!-- Right Content Area -->
-                <Grid Grid.Column="1" Margin="24,20,24,22" VerticalAlignment="Stretch">
+                <Grid Grid.Column="1" Margin="20,16,20,18" VerticalAlignment="Stretch">
                     <!-- Dashboard Page -->
                     <Grid VerticalAlignment="Stretch">
                         <Grid.Style>
@@ -458,39 +557,45 @@
                         </Grid.RowDefinitions>
 
                         <!-- Dashboard Info Header -->
-                        <Grid Grid.Row="0" Margin="0,0,0,18">
+                        <Grid Grid.Row="0" Margin="0,0,0,14">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <StackPanel>
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                    <Ellipse Width="5" Height="5" Fill="{DynamicResource AccentBrush}" Margin="0,0,7,0" VerticalAlignment="Center" />
-                                    <TextBlock Text="收纳概览"
+                                    <Border Width="16"
+                                            Height="3"
+                                            Background="{DynamicResource AccentBrush}"
+                                            CornerRadius="2"
+                                            Margin="0,0,7,0"
+                                            VerticalAlignment="Center" />
+                                    <TextBlock Text="{Binding SelectedBox.Description, TargetNullValue=选择左侧的收纳盒开始整理}"
                                                Foreground="{DynamicResource TextMutedBrush}"
-                                               FontSize="11.5"
-                                               FontWeight="Bold"
+                                               FontSize="11"
+                                               FontWeight="SemiBold"
                                                />
                                 </StackPanel>
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,4,0,0">
                                     <TextBlock Text="{Binding SelectedBox.Name, TargetNullValue=选择一个收纳盒}"
                                                Foreground="{DynamicResource TextPrimaryBrush}"
-                                               FontSize="26"
-                                               FontWeight="Bold" />
+                                               FontSize="24"
+                                               FontWeight="SemiBold" />
                                     
                                     <!-- 重命名收纳盒悬浮按钮与浮窗 -->
-                                    <Grid Margin="12,4,0,0">
+                                    <Grid Margin="10,4,0,0">
                                          <Button x:Name="BtnRenameBox"
                                                  Click="OnRenameBoxClicked"
                                                  Focusable="False"
                                                  Style="{StaticResource GhostButtonStyle}"
-                                                 Width="32" Height="32"
+                                                 AutomationProperties.Name="重命名当前收纳盒"
+                                                 Width="30" Height="30"
                                                  Padding="0"
                                                  ToolTip="重命名收纳盒"
                                                  BorderThickness="0">
                                             <Path Data="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.9959.9959 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
                                                   Fill="{DynamicResource TextMutedBrush}"
-                                                  Stretch="Uniform" Width="16" Height="16" />
+                                                  Stretch="Uniform" Width="14" Height="14" />
                                         </Button>
 
                                         <Popup x:Name="RenameBoxPopup"
@@ -515,8 +620,8 @@
                                                              Width="180" Height="32"
                                                              VerticalContentAlignment="Center"
                                                              Foreground="{DynamicResource TextPrimaryBrush}"
-                                                             Background="{DynamicResource BackgroundBrush}"
-                                                             BorderBrush="{DynamicResource BorderBrush}"
+                                                             Background="{DynamicResource PanelBrush}"
+                                                             BorderBrush="{DynamicResource BorderBrushSoft}"
                                                              BorderThickness="1"
                                                              Padding="8,0"
                                                              KeyDown="OnRenameBoxKeyDown"
@@ -530,47 +635,169 @@
                                             </Border>
                                         </Popup>
                                     </Grid>
+
+                                    <Grid Margin="4,4,0,0">
+                                        <Button x:Name="BtnLockBoxPosition"
+                                                Command="{Binding ToggleSelectedBoxPositionLockCommand}"
+                                                AutomationProperties.Name="{Binding SelectedBox.PositionLockButtonAutomationName}"
+                                                Width="30"
+                                                Height="30"
+                                                MinWidth="30"
+                                                MinHeight="30"
+                                                Padding="0"
+                                                ToolTip="{Binding SelectedBox.PositionLockButtonToolTip}"
+                                                BorderThickness="0">
+                                            <Button.Style>
+                                                <Style TargetType="{x:Type Button}"
+                                                       BasedOn="{StaticResource GhostButtonStyle}">
+                                                    <Setter Property="Foreground" Value="{DynamicResource TextMutedBrush}" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding SelectedBox.IsPositionLocked}" Value="True">
+                                                            <Setter Property="Background" Value="{DynamicResource AccentSoftBrush}" />
+                                                            <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Button.Style>
+                                            <Path Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                                  StrokeThickness="1.45"
+                                                  StrokeStartLineCap="Round"
+                                                  StrokeEndLineCap="Round"
+                                                  StrokeLineJoin="Round"
+                                                  Width="16"
+                                                  Height="16"
+                                                  Stretch="Uniform"
+                                                  SnapsToDevicePixels="True">
+                                                <Path.Style>
+                                                    <Style TargetType="{x:Type Path}">
+                                                        <Setter Property="Data"
+                                                                Value="M 6,8 L 6,6 C 6,3.8 7.8,2 10,2 C 11.7,2 13.2,3.1 13.7,4.7 M 4,8 L 16,8 L 16,18 L 4,18 Z M 10,11 L 10,15" />
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding SelectedBox.IsPositionLocked}" Value="True">
+                                                                <Setter Property="Data"
+                                                                        Value="M 6,8 L 6,6 C 6,3.8 7.8,2 10,2 C 12.2,2 14,3.8 14,6 L 14,8 M 4,8 L 16,8 L 16,18 L 4,18 Z M 10,11 L 10,15" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Path.Style>
+                                            </Path>
+                                        </Button>
+                                    </Grid>
+
+                                    <Grid Margin="4,4,0,0">
+                                        <Button x:Name="BtnDeleteBox"
+                                                Click="OnDeleteBoxClicked"
+                                                Style="{StaticResource DangerButtonStyle}"
+                                                AutomationProperties.Name="删除当前收纳盒"
+                                                Width="30"
+                                                Height="30"
+                                                MinWidth="30"
+                                                MinHeight="30"
+                                                Padding="0"
+                                                ToolTip="删除当前收纳盒"
+                                                BorderThickness="0">
+                                            <Path Data="M 2,4 L 16,4 M 6,4 L 6,2 L 12,2 L 12,4 M 4.5,4 L 5.4,17 L 12.6,17 L 13.5,4 M 8,7 L 8,14 M 10,7 L 10,14"
+                                                  Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                                  StrokeThickness="1.45"
+                                                  StrokeStartLineCap="Round"
+                                                  StrokeEndLineCap="Round"
+                                                  Width="16"
+                                                  Height="16"
+                                                  Stretch="Uniform"
+                                                  SnapsToDevicePixels="True" />
+                                        </Button>
+
+                                        <Popup x:Name="DeleteConfirmPopup"
+                                               StaysOpen="False"
+                                               AllowsTransparency="True"
+                                               PlacementTarget="{Binding ElementName=BtnDeleteBox}"
+                                               Placement="Bottom"
+                                               VerticalOffset="6"
+                                               HorizontalOffset="-92"
+                                               PopupAnimation="Fade">
+                                            <Border Background="{DynamicResource PanelBrush}"
+                                                    BorderBrush="{DynamicResource BorderBrushSoft}"
+                                                    BorderThickness="1"
+                                                    CornerRadius="14"
+                                                    Padding="16,14"
+                                                    Margin="16">
+                                                <Border.Effect>
+                                                    <DropShadowEffect BlurRadius="18"
+                                                                      ShadowDepth="5"
+                                                                      Opacity="0.16"
+                                                                      Direction="270" />
+                                                </Border.Effect>
+                                                <StackPanel MinWidth="210">
+                                                    <TextBlock Text="删除这个收纳盒？"
+                                                               FontWeight="SemiBold"
+                                                               FontSize="13"
+                                                               Foreground="{DynamicResource TextPrimaryBrush}"
+                                                               Margin="0,0,0,6" />
+                                                    <TextBlock Text="{Binding SelectedBox.DeleteWarning}"
+                                                               FontSize="11.5"
+                                                               Foreground="{DynamicResource TextMutedBrush}"
+                                                               Margin="0,0,0,14"
+                                                               TextWrapping="Wrap" />
+                                                    <StackPanel Orientation="Horizontal"
+                                                                HorizontalAlignment="Right">
+                                                        <Button Content="取消"
+                                                                Click="OnCancelDeleteBoxClicked"
+                                                                Style="{StaticResource GhostButtonStyle}"
+                                                                Margin="0,0,6,0"
+                                                                Padding="12,5" />
+                                                        <Button Content="删除"
+                                                                Click="OnConfirmDeleteBoxClicked"
+                                                                Style="{StaticResource DangerButtonStyle}"
+                                                                Padding="14,5" />
+                                                    </StackPanel>
+                                                </StackPanel>
+                                            </Border>
+                                        </Popup>
+                                    </Grid>
                                 </StackPanel>
                             </StackPanel>
 
-                            <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom">
+                            <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
                                 <Border Background="{DynamicResource AccentSoftBrush}"
                                         BorderBrush="Transparent"
                                         BorderThickness="1"
-                                        CornerRadius="11"
-                                        Padding="11,6"
+                                        CornerRadius="8"
+                                        Padding="9,5"
                                         Margin="0,0,8,0">
                                     <StackPanel Orientation="Horizontal">
                                         <Path Data="M 1,4 L 10,1 L 19,4 L 19,15 L 10,18 L 1,15 Z M 1,4 L 10,7 L 19,4 M 10,7 L 10,18" 
                                               Stroke="{DynamicResource AccentBrush}" StrokeThickness="1.2" Width="12" Height="12" VerticalAlignment="Center" Margin="0,0,6,0" />
                                         <TextBlock Text="{Binding Boxes.Count, StringFormat={}{0} 个收纳盒}"
-                                                   Foreground="{DynamicResource AccentBrush}" FontSize="11.5" FontWeight="SemiBold" />
+                                                   Foreground="{DynamicResource AccentBrush}" FontSize="11" FontWeight="SemiBold" />
                                     </StackPanel>
                                 </Border>
                                 <Border Background="{DynamicResource PanelBrush}"
                                         BorderBrush="{DynamicResource BorderBrushSoft}"
                                         BorderThickness="1"
-                                        CornerRadius="11"
-                                        Padding="11,6">
+                                        CornerRadius="8"
+                                        Padding="9,5">
                                     <StackPanel Orientation="Horizontal">
                                         <Path Data="M 2,1 L 9,1 L 13,5 L 13,14 L 2,14 Z M 9,1 L 9,5 L 13,5" 
                                               Stroke="{DynamicResource TextMutedBrush}" StrokeThickness="1.2" Width="11" Height="12" VerticalAlignment="Center" Margin="0,0,6,0" />
                                         <TextBlock Text="{Binding Items.Count, StringFormat={}{0} 个文件}"
-                                                   Foreground="{DynamicResource TextMutedBrush}" FontSize="11.5" FontWeight="SemiBold" />
+                                                   Foreground="{DynamicResource TextMutedBrush}" FontSize="11" FontWeight="SemiBold" />
                                     </StackPanel>
                                 </Border>
                             </StackPanel>
                         </Grid>
 
                         <Grid Grid.Row="1" VerticalAlignment="Stretch">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="220" />
-                                <ColumnDefinition Width="16" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
 
-                            <!-- 左侧卡片自适应容器 (采用高度纵向拉伸 Grid，实现与右侧完美对称对齐) -->
-                            <Grid Grid.Column="0" Margin="0,0,8,0" VerticalAlignment="Stretch">
+                            <!-- Selected box controls -->
+                            <Grid Grid.Row="0" Margin="0,0,0,10" VerticalAlignment="Stretch">
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto" /> <!-- 顶部状态卡片 -->
                                     <RowDefinition Height="Auto" /> <!-- 收纳盒属性配置卡片 -->
@@ -583,7 +810,8 @@
                                         BorderBrush="{DynamicResource BorderBrushSoft}"
                                         BorderThickness="1"
                                         CornerRadius="16"
-                                        Margin="0,0,0,10">
+                                        Margin="0,0,0,10"
+                                        Visibility="Collapsed">
                                     <Grid>
                                         <Border CornerRadius="16" IsHitTestVisible="False" Opacity="0.45">
                                             <Border.Background>
@@ -618,176 +846,220 @@
                                         Background="{DynamicResource PanelBrush}"
                                         BorderBrush="{DynamicResource BorderBrushSoft}"
                                         BorderThickness="1"
-                                        CornerRadius="16"
-                                        Padding="13"
-                                        Margin="0,0,0,10">
-                                    <StackPanel>
-                                        <!-- 第一层：当前模式与删除小按钮的左右并排 -->
-                                        <Grid>
+                                        CornerRadius="12"
+                                        Padding="12"
+                                        Margin="0">
+                                    <Grid x:Name="BoxControlsPageHost"
+                                          MinHeight="34"
+                                          ClipToBounds="True">
+                                        <VisualStateManager.VisualStateGroups>
+                                            <VisualStateGroup x:Name="BoxControlsPageStates">
+                                                <VisualStateGroup.Transitions>
+                                                    <VisualTransition GeneratedDuration="0:0:0.2">
+                                                        <VisualTransition.GeneratedEasingFunction>
+                                                            <CubicEase EasingMode="EaseOut" />
+                                                        </VisualTransition.GeneratedEasingFunction>
+                                                    </VisualTransition>
+                                                </VisualStateGroup.Transitions>
+                                                <VisualState x:Name="PrimaryControlsState">
+                                                    <Storyboard>
+                                                        <DoubleAnimation Storyboard.TargetName="BoxControlsPrimaryPanel"
+                                                                         Storyboard.TargetProperty="Opacity"
+                                                                         To="1" />
+                                                        <DoubleAnimation Storyboard.TargetName="BoxControlsPrimaryTransform"
+                                                                         Storyboard.TargetProperty="X"
+                                                                         To="0" />
+                                                        <DoubleAnimation Storyboard.TargetName="BoxVisualStyleSecondaryPanel"
+                                                                         Storyboard.TargetProperty="Opacity"
+                                                                         To="0" />
+                                                        <DoubleAnimation Storyboard.TargetName="BoxVisualStyleSecondaryTransform"
+                                                                         Storyboard.TargetProperty="X"
+                                                                         To="28" />
+                                                    </Storyboard>
+                                                </VisualState>
+                                                <VisualState x:Name="VisualStyleSelectionState">
+                                                    <Storyboard>
+                                                        <DoubleAnimation Storyboard.TargetName="BoxControlsPrimaryPanel"
+                                                                         Storyboard.TargetProperty="Opacity"
+                                                                         To="0" />
+                                                        <DoubleAnimation Storyboard.TargetName="BoxControlsPrimaryTransform"
+                                                                         Storyboard.TargetProperty="X"
+                                                                         To="-28" />
+                                                        <DoubleAnimation Storyboard.TargetName="BoxVisualStyleSecondaryPanel"
+                                                                         Storyboard.TargetProperty="Opacity"
+                                                                         To="1" />
+                                                        <DoubleAnimation Storyboard.TargetName="BoxVisualStyleSecondaryTransform"
+                                                                         Storyboard.TargetProperty="X"
+                                                                         To="0" />
+                                                    </Storyboard>
+                                                </VisualState>
+                                            </VisualStateGroup>
+                                        </VisualStateManager.VisualStateGroups>
+
+                                        <Grid x:Name="BoxControlsPrimaryPanel"
+                                              Height="34"
+                                              VerticalAlignment="Center">
+                                            <Grid.RenderTransform>
+                                                <TranslateTransform x:Name="BoxControlsPrimaryTransform" />
+                                            </Grid.RenderTransform>
+                                            <Grid.Resources>
+                                                <Style x:Key="BoxControlLabelStyle"
+                                                       TargetType="{x:Type TextBlock}">
+                                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
+                                                    <Setter Property="FontSize" Value="11.5" />
+                                                    <Setter Property="FontWeight" Value="SemiBold" />
+                                                    <Setter Property="VerticalAlignment" Value="Center" />
+                                                </Style>
+                                                <Style x:Key="VisualStylePickerButtonStyle"
+                                                       TargetType="{x:Type Button}"
+                                                       BasedOn="{StaticResource {x:Type Button}}">
+                                                    <Setter Property="Height" Value="28" />
+                                                    <Setter Property="MinHeight" Value="28" />
+                                                    <Setter Property="MinWidth" Value="78" />
+                                                    <Setter Property="Padding" Value="10,0" />
+                                                    <Setter Property="Background" Value="{DynamicResource AccentSoftBrush}" />
+                                                    <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                                                    <Setter Property="BorderThickness" Value="1" />
+                                                    <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
+                                                    <Setter Property="FontSize" Value="10.5" />
+                                                    <Setter Property="FontWeight" Value="SemiBold" />
+                                                    <Style.Triggers>
+                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                            <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                                                        </Trigger>
+                                                        <Trigger Property="IsKeyboardFocused" Value="True">
+                                                            <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                                                            <Setter Property="BorderThickness" Value="2" />
+                                                        </Trigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Grid.Resources>
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="*" />
-                                                <ColumnDefinition Width="Auto" />
-                                            </Grid.ColumnDefinitions>
-                                            
-                                            <StackPanel Grid.Column="0" VerticalAlignment="Center">
-                                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                                    <TextBlock Text="当前模式"
-                                                               Foreground="{DynamicResource TextMutedBrush}"
-                                                               FontSize="11.5"
-                                                               FontWeight="Bold"
-                                                               VerticalAlignment="Center" />
-                                                    <Border Background="{DynamicResource AccentSoftBrush}"
-                                                            CornerRadius="6"
-                                                            Padding="6,2"
-                                                            Margin="8,0,0,0"
-                                                            VerticalAlignment="Center">
-                                                        <TextBlock Text="{Binding SelectedBox.TypeLabel}"
-                                                                   Foreground="{DynamicResource AccentBrush}"
-                                                                   FontSize="10.5"
-                                                                   FontWeight="Bold" />
-                                                    </Border>
-                                                </StackPanel>
-                                                <TextBlock Text="{Binding SelectedBox.Description}"
-                                                           Foreground="{DynamicResource TextMutedBrush}"
-                                                           FontSize="11"
-                                                           LineHeight="13"
-                                                           Margin="0,4,0,0"
-                                                           TextWrapping="Wrap" />
-                                            </StackPanel>
-
-                                            <!-- 微型悬浮垃圾桶小按钮与高质感二次确认浮窗 -->
-                                            <Grid Grid.Column="1" VerticalAlignment="Top" HorizontalAlignment="Right">
-                                                <Button x:Name="BtnDeleteBox"
-                                                        Click="OnDeleteBoxClicked"
-                                                        Style="{StaticResource DangerButtonStyle}"
-                                                        Width="34"
-                                                        Height="34"
-                                                        MinWidth="34"
-                                                        MinHeight="34"
-                                                        Padding="0"
-                                                        ToolTip="删除当前收纳盒"
-                                                        BorderThickness="0">
-                                                    <Path Data="M 3,3 L 13,3 M 4,3 L 4,14 C 4,15 5,16 6,16 L 10,16 C 11,16 12,15 12,14 L 12,3 M 6,3 L 6,1 L 10,1 L 10,3" 
-                                                          Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}" 
-                                                          StrokeThickness="1.2" 
-                                                          Width="13" 
-                                                          Height="14" 
-                                                          Stretch="Uniform" 
-                                                          SnapsToDevicePixels="True" />
-                                                </Button>
-                                                
-                                                <!-- 定制级极简二次确认玻璃悬浮窗 -->
-                                                <Popup x:Name="DeleteConfirmPopup"
-                                                       StaysOpen="False"
-                                                       AllowsTransparency="True"
-                                                       PlacementTarget="{Binding ElementName=BtnDeleteBox}"
-                                                       Placement="Bottom"
-                                                       VerticalOffset="6"
-                                                       HorizontalOffset="-130"
-                                                       PopupAnimation="Fade">
-                                                    <Border Background="{DynamicResource PanelBrush}"
-                                                            BorderBrush="{DynamicResource BorderBrushSoft}"
-                                                            BorderThickness="1"
-                                                            CornerRadius="14"
-                                                            Padding="16,14"
-                                                            Margin="16">
-                                                        <Border.Effect>
-                                                            <DropShadowEffect BlurRadius="20" ShadowDepth="6" Opacity="0.18" Direction="270" />
-                                                        </Border.Effect>
-                                                        <StackPanel MinWidth="200">
-                                                            <TextBlock Text="确定要删除该收纳盒吗？" FontWeight="SemiBold" FontSize="13" Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,6"/>
-                                                            <TextBlock Text="{Binding SelectedBox.DeleteWarning}" FontSize="11.5" Foreground="{DynamicResource TextMutedBrush}" Margin="0,0,0,16" TextWrapping="Wrap"/>
-                                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                                                                <Button Content="取消" Click="OnCancelDeleteBoxClicked" Style="{StaticResource GhostButtonStyle}" Margin="0,0,8,0" Padding="12,6"/>
-                                                                <Button Content="删除" Click="OnConfirmDeleteBoxClicked" Style="{StaticResource DangerButtonStyle}" Padding="16,6"/>
-                                                            </StackPanel>
-                                                        </StackPanel>
-                                                    </Border>
-                                                </Popup>
-                                            </Grid>
-                                        </Grid>
-
-                                        <!-- 极简精致微透分割线 -->
-                                        <Border Height="1" 
-                                                Background="{DynamicResource BorderBrushSoft}" 
-                                                Margin="0,11,0,11"
-                                                Opacity="0.45" />
-
-                                        <!-- 第二层：桌面图标排列密度左右并排布局，极速压缩高度 -->
-                                        <Grid>
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="132" />
+                                                <ColumnDefinition Width="178" />
                                                 <ColumnDefinition Width="*" />
                                             </Grid.ColumnDefinitions>
-                                            
-                                            <StackPanel Grid.Column="0"
-                                                        Orientation="Horizontal"
+
+                                            <Grid Grid.Column="0"
+                                                  Height="34"
+                                                  Margin="0,0,12,0"
+                                                  VerticalAlignment="Center">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+                                                <TextBlock Text="收纳方式"
+                                                           Style="{StaticResource BoxControlLabelStyle}" />
+                                                <Border Grid.Column="1"
+                                                        Margin="8,0,0,0"
+                                                        Padding="6,2"
                                                         VerticalAlignment="Center"
-                                                        Margin="0,0,8,0">
-                                                <TextBlock Text="图标大小"
-                                                           Foreground="{DynamicResource TextPrimaryBrush}"
-                                                           FontSize="11.5"
-                                                           FontWeight="Bold"
-                                                           VerticalAlignment="Center" />
-                                                <Border Background="{DynamicResource AccentSoftBrush}"
-                                                        CornerRadius="6"
-                                                        Margin="6,0,0,0"
-                                                        Padding="6,2">
-                                                    <TextBlock Text="{Binding SelectedBox.LayoutSettings.CurrentSizeLabel, TargetNullValue=小}"
+                                                        Background="{DynamicResource AccentSoftBrush}"
+                                                        CornerRadius="6">
+                                                    <TextBlock Text="{Binding SelectedBox.TypeLabel}"
                                                                Foreground="{DynamicResource AccentBrush}"
-                                                               FontSize="10"
-                                                               FontWeight="SemiBold"
-                                                               HorizontalAlignment="Center" />
+                                                               FontSize="10.5"
+                                                               FontWeight="SemiBold" />
                                                 </Border>
-                                            </StackPanel>
+                                            </Grid>
 
-                                            <!-- 胶囊样式小按钮组，提供流畅的桌面网格排列控制 -->
-                                            <UniformGrid Grid.Column="1" Columns="4" Rows="1" VerticalAlignment="Center">
+                                            <Grid Grid.Column="1"
+                                                  Height="34"
+                                                  Margin="8,0,12,0"
+                                                  VerticalAlignment="Center"
+                                                  Visibility="{Binding SelectedBox.CanSelectVisualStyle, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto" />
+                                                    <ColumnDefinition Width="Auto" />
+                                                </Grid.ColumnDefinitions>
+                                                <TextBlock Text="图标风格"
+                                                           Style="{StaticResource BoxControlLabelStyle}" />
+                                                <Button x:Name="BoxVisualStyleDrawerToggle"
+                                                        Grid.Column="1"
+                                                        Margin="8,0,0,0"
+                                                        Content="{Binding SelectedBox.VisualStyleLabel}"
+                                                        Style="{StaticResource VisualStylePickerButtonStyle}"
+                                                        ToolTip="选择图标风格"
+                                                        Click="OnOpenBoxVisualStylePage" />
+                                            </Grid>
+
+                                            <Grid Grid.Column="2"
+                                                  Height="34"
+                                                  Margin="8,0,0,0"
+                                                  VerticalAlignment="Center">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto" />
+                                                    <ColumnDefinition Width="*" />
+                                                </Grid.ColumnDefinitions>
+                                                <TextBlock Text="图标大小"
+                                                           Margin="0,0,10,0"
+                                                           Style="{StaticResource BoxControlLabelStyle}" />
+
+                                                <Border Grid.Column="1"
+                                                    Height="34"
+                                                    Background="{DynamicResource PanelAltBrush}"
+                                                    BorderBrush="{DynamicResource BorderBrushSoft}"
+                                                    BorderThickness="1"
+                                                    CornerRadius="10"
+                                                    Padding="2">
+                                            <UniformGrid Columns="4" Rows="1" VerticalAlignment="Center">
                                                 <UniformGrid.Resources>
-                                                    <Style x:Key="ExtraLargeIconSizeButtonStyle"
+                                                    <Style x:Key="IconSizeChoiceButtonStyle"
                                                            TargetType="{x:Type Button}"
                                                            BasedOn="{StaticResource GhostButtonStyle}">
+                                                        <Setter Property="Background" Value="Transparent" />
+                                                        <Setter Property="BorderBrush" Value="Transparent" />
+                                                        <Setter Property="BorderThickness" Value="0" />
+                                                        <Setter Property="Foreground" Value="{DynamicResource TextMutedBrush}" />
+                                                        <Setter Property="MinHeight" Value="28" />
+                                                        <Setter Property="Padding" Value="10,4" />
+                                                        <Setter Property="FontSize" Value="10.5" />
+                                                        <Setter Property="FontWeight" Value="Medium" />
+                                                    </Style>
+                                                    <Style x:Key="ExtraLargeIconSizeButtonStyle"
+                                                           TargetType="{x:Type Button}"
+                                                           BasedOn="{StaticResource IconSizeChoiceButtonStyle}">
                                                         <Style.Triggers>
                                                             <DataTrigger Binding="{Binding SelectedBox.LayoutSettings.IsExtraLargePreset}" Value="True">
-                                                                <Setter Property="Background" Value="{DynamicResource AccentSoftBrush}" />
-                                                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
-                                                                <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
+                                                                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+                                                                <Setter Property="BorderBrush" Value="Transparent" />
+                                                                <Setter Property="Foreground" Value="White" />
                                                                 <Setter Property="FontWeight" Value="SemiBold" />
                                                             </DataTrigger>
                                                         </Style.Triggers>
                                                     </Style>
                                                     <Style x:Key="LargeIconSizeButtonStyle"
                                                            TargetType="{x:Type Button}"
-                                                           BasedOn="{StaticResource GhostButtonStyle}">
+                                                           BasedOn="{StaticResource IconSizeChoiceButtonStyle}">
                                                         <Style.Triggers>
                                                             <DataTrigger Binding="{Binding SelectedBox.LayoutSettings.IsLargePreset}" Value="True">
-                                                                <Setter Property="Background" Value="{DynamicResource AccentSoftBrush}" />
-                                                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
-                                                                <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
+                                                                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+                                                                <Setter Property="BorderBrush" Value="Transparent" />
+                                                                <Setter Property="Foreground" Value="White" />
                                                                 <Setter Property="FontWeight" Value="SemiBold" />
                                                             </DataTrigger>
                                                         </Style.Triggers>
                                                     </Style>
                                                     <Style x:Key="MediumIconSizeButtonStyle"
                                                            TargetType="{x:Type Button}"
-                                                           BasedOn="{StaticResource GhostButtonStyle}">
+                                                           BasedOn="{StaticResource IconSizeChoiceButtonStyle}">
                                                         <Style.Triggers>
                                                             <DataTrigger Binding="{Binding SelectedBox.LayoutSettings.IsMediumPreset}" Value="True">
-                                                                <Setter Property="Background" Value="{DynamicResource AccentSoftBrush}" />
-                                                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
-                                                                <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
+                                                                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+                                                                <Setter Property="BorderBrush" Value="Transparent" />
+                                                                <Setter Property="Foreground" Value="White" />
                                                                 <Setter Property="FontWeight" Value="SemiBold" />
                                                             </DataTrigger>
                                                         </Style.Triggers>
                                                     </Style>
                                                     <Style x:Key="SmallIconSizeButtonStyle"
                                                            TargetType="{x:Type Button}"
-                                                           BasedOn="{StaticResource GhostButtonStyle}">
+                                                           BasedOn="{StaticResource IconSizeChoiceButtonStyle}">
                                                         <Style.Triggers>
                                                             <DataTrigger Binding="{Binding SelectedBox.LayoutSettings.IsSmallPreset}" Value="True">
-                                                                <Setter Property="Background" Value="{DynamicResource AccentSoftBrush}" />
-                                                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
-                                                                <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
+                                                                <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
+                                                                <Setter Property="BorderBrush" Value="Transparent" />
+                                                                <Setter Property="Foreground" Value="White" />
                                                                 <Setter Property="FontWeight" Value="SemiBold" />
                                                             </DataTrigger>
                                                         </Style.Triggers>
@@ -797,41 +1069,176 @@
                                                         ToolTip="超大图标"
                                                         Style="{StaticResource ExtraLargeIconSizeButtonStyle}"
                                                         Command="{Binding SelectedBox.LayoutSettings.ApplyPresetCommand}"
-                                                        CommandParameter="3x3"
-                                                        Margin="0,0,2,0"
-                                                        Padding="0,3.5"
-                                                        MinHeight="22"
-                                                        FontSize="10.5" />
+                                                        CommandParameter="3x3" />
                                                 <Button Content="大"
                                                         ToolTip="大图标"
                                                         Style="{StaticResource LargeIconSizeButtonStyle}"
                                                         Command="{Binding SelectedBox.LayoutSettings.ApplyPresetCommand}"
-                                                        CommandParameter="4x4"
-                                                        Margin="0,0,2,0"
-                                                        Padding="0,3.5"
-                                                        MinHeight="22"
-                                                        FontSize="10.5" />
+                                                        CommandParameter="4x4" />
                                                 <Button Content="中"
                                                         ToolTip="中等图标"
                                                         Style="{StaticResource MediumIconSizeButtonStyle}"
                                                         Command="{Binding SelectedBox.LayoutSettings.ApplyPresetCommand}"
-                                                        CommandParameter="5x5"
-                                                        Margin="0,0,2,0"
-                                                        Padding="0,3.5"
-                                                        MinHeight="22"
-                                                        FontSize="10.5" />
+                                                        CommandParameter="5x5" />
                                                 <Button Content="小"
                                                         ToolTip="小图标"
                                                         Style="{StaticResource SmallIconSizeButtonStyle}"
                                                         Command="{Binding SelectedBox.LayoutSettings.ApplyPresetCommand}"
-                                                        CommandParameter="6x6"
-                                                        Padding="0,3.5"
-                                                        MinHeight="22"
-                                                        FontSize="10.5" />
-                                            </UniformGrid>
+                                                        CommandParameter="6x6" />
+                                                </UniformGrid>
+                                                </Border>
+                                            </Grid>
                                         </Grid>
-                                    </StackPanel>
-                                </Border>
+
+                                        <Grid x:Name="BoxVisualStyleSecondaryPanel"
+                                              Opacity="0"
+                                              IsHitTestVisible="False">
+                                            <Grid.RenderTransform>
+                                                <TranslateTransform x:Name="BoxVisualStyleSecondaryTransform"
+                                                                    X="28" />
+                                            </Grid.RenderTransform>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="*" />
+                                            </Grid.ColumnDefinitions>
+                                            <Button Grid.Column="0"
+                                                    Width="28"
+                                                    Height="28"
+                                                    Margin="0,0,8,0"
+                                                    Padding="0"
+                                                    Style="{StaticResource GhostButtonStyle}"
+                                                    Click="OnCloseBoxVisualStylePage"
+                                                    ToolTip="返回">
+                                                <TextBlock Text="&#xE72B;"
+                                                           FontFamily="Segoe Fluent Icons"
+                                                           FontSize="11"
+                                                           Foreground="{DynamicResource TextMutedBrush}"
+                                                           HorizontalAlignment="Center"
+                                                           VerticalAlignment="Center" />
+                                            </Button>
+                                            <StackPanel Grid.Column="1"
+                                                        Margin="0,0,12,0"
+                                                        VerticalAlignment="Center">
+                                                <TextBlock Text="选择图标风格"
+                                                           Foreground="{DynamicResource TextPrimaryBrush}"
+                                                           FontSize="11.5"
+                                                           FontWeight="SemiBold" />
+                                                <TextBlock Text="点击后立即应用"
+                                                           Foreground="{DynamicResource TextMutedBrush}"
+                                                           FontSize="9.5"
+                                                           Margin="0,1,0,0" />
+                                            </StackPanel>
+                                            <Border Grid.Column="2"
+                                                    Padding="2"
+                                                    Background="{DynamicResource PanelAltBrush}"
+                                                    BorderBrush="{DynamicResource BorderBrushSoft}"
+                                                    BorderThickness="1"
+                                                    CornerRadius="10">
+                                                <ItemsControl ItemsSource="{Binding BoxVisualStyleOptions}">
+                                                    <ItemsControl.ItemsPanel>
+                                                        <ItemsPanelTemplate>
+                                                            <UniformGrid Columns="2" />
+                                                        </ItemsPanelTemplate>
+                                                    </ItemsControl.ItemsPanel>
+                                                    <ItemsControl.ItemTemplate>
+                                                        <DataTemplate>
+                                                            <Button Click="OnBoxVisualStyleSelected"
+                                                                    Margin="2"
+                                                                    Padding="8,7"
+                                                                    HorizontalContentAlignment="Stretch">
+                                                                <Button.Style>
+                                                                    <Style TargetType="{x:Type Button}"
+                                                                           BasedOn="{StaticResource GhostButtonStyle}">
+                                                                        <Setter Property="Background" Value="Transparent" />
+                                                                        <Setter Property="BorderBrush" Value="Transparent" />
+                                                                        <Setter Property="BorderThickness" Value="1" />
+                                                                        <Setter Property="Foreground" Value="{DynamicResource TextMutedBrush}" />
+                                                                        <Setter Property="RenderTransformOrigin" Value="0.5,0.5" />
+                                                                        <Setter Property="RenderTransform">
+                                                                            <Setter.Value>
+                                                                                <ScaleTransform ScaleX="1" ScaleY="1" />
+                                                                            </Setter.Value>
+                                                                        </Setter>
+                                                                        <Style.Triggers>
+                                                                            <Trigger Property="IsMouseOver" Value="True">
+                                                                                <Setter Property="Background" Value="{DynamicResource HoverBrush}" />
+                                                                            </Trigger>
+                                                                            <DataTrigger Value="True">
+                                                                                <DataTrigger.Binding>
+                                                                                    <MultiBinding Converter="{StaticResource BoxVisualStyleEqualityConverter}">
+                                                                                        <Binding Path="Style" />
+                                                                                        <Binding Path="DataContext.SelectedBox.VisualStyle"
+                                                                                                 RelativeSource="{RelativeSource AncestorType={x:Type ItemsControl}}" />
+                                                                                    </MultiBinding>
+                                                                                </DataTrigger.Binding>
+                                                                                <Setter Property="Background" Value="{DynamicResource AccentSoftBrush}" />
+                                                                                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                                                                                <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
+                                                                                <DataTrigger.EnterActions>
+                                                                                    <BeginStoryboard>
+                                                                                        <Storyboard>
+                                                                                            <DoubleAnimation Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
+                                                                                                             From="0.94"
+                                                                                                             To="1"
+                                                                                                             Duration="0:0:0.18">
+                                                                                                <DoubleAnimation.EasingFunction>
+                                                                                                    <BackEase Amplitude="0.28"
+                                                                                                              EasingMode="EaseOut" />
+                                                                                                </DoubleAnimation.EasingFunction>
+                                                                                            </DoubleAnimation>
+                                                                                            <DoubleAnimation Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
+                                                                                                             From="0.94"
+                                                                                                             To="1"
+                                                                                                             Duration="0:0:0.18">
+                                                                                                <DoubleAnimation.EasingFunction>
+                                                                                                    <BackEase Amplitude="0.28"
+                                                                                                              EasingMode="EaseOut" />
+                                                                                                </DoubleAnimation.EasingFunction>
+                                                                                            </DoubleAnimation>
+                                                                                        </Storyboard>
+                                                                                    </BeginStoryboard>
+                                                                                </DataTrigger.EnterActions>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </Button.Style>
+                                                                <Grid>
+                                                                    <Grid.ColumnDefinitions>
+                                                                        <ColumnDefinition Width="28" />
+                                                                        <ColumnDefinition Width="*" />
+                                                                    </Grid.ColumnDefinitions>
+                                                                    <Border Width="24"
+                                                                            Height="24"
+                                                                            CornerRadius="7"
+                                                                            Background="{DynamicResource AccentSoftBrush}">
+                                                                        <TextBlock Text="{Binding Glyph}"
+                                                                                   FontFamily="Segoe Fluent Icons"
+                                                                                   FontSize="12"
+                                                                                   Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                                                                   HorizontalAlignment="Center"
+                                                                                   VerticalAlignment="Center" />
+                                                                    </Border>
+                                                                    <StackPanel Grid.Column="1" Margin="6,0,0,0">
+                                                                        <TextBlock Text="{Binding Name}"
+                                                                                   Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                                                                   FontSize="11"
+                                                                                   FontWeight="SemiBold" />
+                                                                        <TextBlock Text="{Binding Description}"
+                                                                                   Foreground="{DynamicResource TextMutedBrush}"
+                                                                                   FontSize="9"
+                                                                                   Margin="0,1,0,0"
+                                                                                   TextTrimming="CharacterEllipsis" />
+                                                                    </StackPanel>
+                                                                </Grid>
+                                                            </Button>
+                                                        </DataTemplate>
+                                                    </ItemsControl.ItemTemplate>
+                                                </ItemsControl>
+                                            </Border>
+                                        </Grid>
+                                    </Grid>
+                                 </Border>
 
                                 <!-- 投放区 (去除硬编码高度，高度由 Grid 自动伸缩拉长并保持居中，实现与右侧完美对称对齐！) -->
                                 <Border Grid.Row="2"
@@ -840,7 +1247,8 @@
                                         BorderThickness="1"
                                         CornerRadius="16"
                                         MinHeight="82"
-                                        VerticalAlignment="Stretch">
+                                        VerticalAlignment="Stretch"
+                                        Visibility="Collapsed">
                                     <Grid>
                                         <Rectangle Stroke="{DynamicResource BorderBrushSoft}"
                                                    StrokeThickness="1"
@@ -869,25 +1277,30 @@
                             </Grid>
 
                             <!-- Right Files List (Glass Card panel) -->
-                            <Border Grid.Column="2"
+                            <Border Grid.Row="1"
                                     Background="{DynamicResource PanelBrush}"
                                     BorderBrush="{DynamicResource BorderBrushSoft}"
                                     BorderThickness="1"
-                                    CornerRadius="16"
-                                    Padding="14">
+                                    CornerRadius="12"
+                                    Padding="12"
+                                    Margin="0,0,0,10">
                                 <DockPanel>
                                     <Grid DockPanel.Dock="Top" Margin="3,1,3,11">
                                         <StackPanel Orientation="Horizontal">
-                                            <Rectangle Width="3"
-                                                       Height="14"
-                                                       RadiusX="1.5"
-                                                       RadiusY="1.5"
-                                                       Fill="{DynamicResource AccentBrush}"
-                                                       Margin="0,0,7,0" />
-                                            <TextBlock Text="文件内容"
+                                            <Border Width="16"
+                                                    Height="3"
+                                                    CornerRadius="2"
+                                                    Background="{DynamicResource AccentBrush}"
+                                                    Margin="0,0,7,0"
+                                                    VerticalAlignment="Center" />
+                                            <TextBlock Text="文件"
                                                        Foreground="{DynamicResource TextPrimaryBrush}"
-                                                       FontSize="12"
+                                                       FontSize="13"
                                                        FontWeight="SemiBold" />
+                                            <TextBlock Text="  ·  双击打开，按 Delete 移除"
+                                                       Foreground="{DynamicResource TextMutedBrush}"
+                                                       FontSize="10.5"
+                                                       VerticalAlignment="Center" />
                                         </StackPanel>
                                         <Border HorizontalAlignment="Right"
                                                 Background="{DynamicResource PanelAltBrush}"
@@ -911,7 +1324,7 @@
                                                            FontSize="14.5"
                                                            FontWeight="SemiBold"
                                                            HorizontalAlignment="Center" />
-                                                <TextBlock Text="把文件拖到左下角的投放区即可归类到此"
+                                                <TextBlock Text="把文件拖到下方投放栏即可归类到这里"
                                                            Foreground="{DynamicResource TextMutedBrush}"
                                                            FontSize="11.5"
                                                            Margin="0,5,0,0"
@@ -1006,43 +1419,132 @@
                                                                        FontSize="12.5"
                                                                        Foreground="{DynamicResource TextPrimaryBrush}"
                                                                        TextTrimming="CharacterEllipsis" />
-                                                            <TextBlock Text="{Binding ShortPathLabel}"
+                                                            <TextBlock Text="{Binding Model.SourcePath, TargetNullValue=路径不可用}"
                                                                        FontSize="10.5"
                                                                        Margin="0,1,0,0"
                                                                        Foreground="{DynamicResource TextMutedBrush}"
-                                                                       TextTrimming="CharacterEllipsis" />
+                                                                       TextTrimming="CharacterEllipsis"
+                                                                       ToolTip="{Binding Model.SourcePath}" />
                                                         </StackPanel>
                                                         
-                                                        <!-- Compact action buttons -->
-                                                        <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
-                                                            <Button Content="打开"
-                                                                    Margin="0,0,6,0"
-                                                                    Height="26"
-                                                                    Padding="10,0"
-                                                                    FontSize="11"
-                                                                    FontWeight="SemiBold"
+                                                        <!-- Actions stay quiet until the row is hovered or selected. -->
+                                                        <StackPanel Grid.Column="2"
+                                                                    Orientation="Horizontal"
+                                                                    VerticalAlignment="Center">
+                                                            <StackPanel.Style>
+                                                                <Style TargetType="{x:Type StackPanel}">
+                                                                    <Setter Property="Opacity" Value="0" />
+                                                                    <Setter Property="IsHitTestVisible" Value="False" />
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=ListBoxItem}}" Value="True">
+                                                                            <Setter Property="Opacity" Value="1" />
+                                                                            <Setter Property="IsHitTestVisible" Value="True" />
+                                                                        </DataTrigger>
+                                                                        <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType=ListBoxItem}}" Value="True">
+                                                                            <Setter Property="Opacity" Value="1" />
+                                                                            <Setter Property="IsHitTestVisible" Value="True" />
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </StackPanel.Style>
+
+                                                            <Button Width="30"
+                                                                    Height="28"
+                                                                    Padding="0"
+                                                                    Margin="0,0,3,0"
                                                                     Foreground="{DynamicResource AccentBrush}"
                                                                     Style="{StaticResource GhostButtonStyle}"
+                                                                    ToolTip="打开"
                                                                     Command="{Binding DataContext.OpenItemCommand, RelativeSource={RelativeSource AncestorType=Window}}"
-                                                                    CommandParameter="{Binding}" />
-                                                            <Button Content="移除"
-                                                                    Height="26"
-                                                                    Padding="10,0"
-                                                                    FontSize="11"
+                                                                    CommandParameter="{Binding}">
+                                                                <Path Data="M 7,2 L 15,2 L 15,10 M 15,2 L 7,10 M 12,7 L 12,15 L 2,15 L 2,5 L 10,5"
+                                                                      Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                                                      StrokeThickness="1.35"
+                                                                      Width="14"
+                                                                      Height="14"
+                                                                      Stretch="Uniform" />
+                                                            </Button>
+                                                            <Button Width="30"
+                                                                    Height="28"
+                                                                    Padding="0"
                                                                     Foreground="{DynamicResource TextMutedBrush}"
                                                                     Style="{StaticResource GhostButtonStyle}"
+                                                                    ToolTip="从收纳盒移除"
                                                                     Command="{Binding DataContext.DeleteItemCommand, RelativeSource={RelativeSource AncestorType=Window}}"
-                                                                    CommandParameter="{Binding}" />
+                                                                    CommandParameter="{Binding}">
+                                                                <Path Data="M 2,4 L 14,4 M 5,4 L 5,2 L 11,2 L 11,4 M 4,4 L 4.8,15 L 11.2,15 L 12,4 M 7,7 L 7,12 M 9,7 L 9,12"
+                                                                      Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                                                      StrokeThickness="1.25"
+                                                                      Width="14"
+                                                                      Height="14"
+                                                                      Stretch="Uniform" />
+                                                            </Button>
                                                         </StackPanel>
                                                     </Grid>
                                                 </DataTemplate>
                                             </ListBox.ItemTemplate>
                                         </ListBox>
                                     </Grid>
-                                </DockPanel>
+                                 </DockPanel>
+                             </Border>
+
+                            <Border Grid.Row="2"
+                                    MinHeight="58"
+                                    Background="{DynamicResource DropZoneBrush}"
+                                    BorderBrush="{DynamicResource BorderBrushSoft}"
+                                    BorderThickness="1"
+                                    CornerRadius="12">
+                                <Grid Margin="13,8">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <Border Width="34"
+                                            Height="34"
+                                            Background="{DynamicResource AccentSoftBrush}"
+                                            CornerRadius="9"
+                                            VerticalAlignment="Center">
+                                        <Path Data="M 7,1 L 7,11 M 3,7 L 7,11 L 11,7 M 2,14 L 12,14"
+                                              Stroke="{DynamicResource AccentBrush}"
+                                              StrokeThickness="1.7"
+                                              StrokeStartLineCap="Round"
+                                              StrokeEndLineCap="Round"
+                                              Width="13"
+                                              Height="15"
+                                              Stretch="Uniform" />
+                                    </Border>
+
+                                    <StackPanel Grid.Column="1"
+                                                Margin="10,0,12,0"
+                                                VerticalAlignment="Center">
+                                        <TextBlock Text="拖入文件到当前收纳盒"
+                                                   Foreground="{DynamicResource TextPrimaryBrush}"
+                                                   FontSize="12.5"
+                                                   FontWeight="SemiBold" />
+                                        <TextBlock Text="普通盒会移动文件，映射盒只保存原路径"
+                                                   Margin="0,2,0,0"
+                                                   Foreground="{DynamicResource TextMutedBrush}"
+                                                   FontSize="10.5" />
+                                    </StackPanel>
+
+                                    <Border Grid.Column="2"
+                                            VerticalAlignment="Center"
+                                            Background="{DynamicResource PanelBrush}"
+                                            BorderBrush="{DynamicResource BorderBrushSoft}"
+                                            BorderThickness="1"
+                                            CornerRadius="8"
+                                            Padding="9,4">
+                                        <TextBlock Text="拖放即可整理"
+                                                   Foreground="{DynamicResource TextMutedBrush}"
+                                                   FontSize="10.5"
+                                                   FontWeight="Medium" />
+                                    </Border>
+                                </Grid>
                             </Border>
-                        </Grid>
-                    </Grid>
+                         </Grid>
+                     </Grid>
 
                     <!-- Todo Archive Page -->
                     <Grid Visibility="{Binding IsArchivePage, Converter={StaticResource BooleanToVisibilityConverter}}">
@@ -1051,25 +1553,25 @@
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
 
-                        <Grid Grid.Row="0" Margin="0,0,0,18">
+                        <Grid Grid.Row="0" Margin="0,0,0,14">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <StackPanel>
-                                <TextBlock Text="待办历史"
-                                           Foreground="{DynamicResource TextMutedBrush}"
-                                           FontSize="12"
-                                           FontWeight="SemiBold" />
+                                 <TextBlock Text="待办历史"
+                                            Foreground="{DynamicResource TextMutedBrush}"
+                                            FontSize="11"
+                                            FontWeight="SemiBold" />
                                 <TextBlock Text="归档"
                                            Margin="0,3,0,0"
                                            Foreground="{DynamicResource TextPrimaryBrush}"
-                                           FontSize="26"
-                                           FontWeight="Bold" />
+                                            FontSize="24"
+                                            FontWeight="SemiBold" />
                                 <TextBlock Text="从桌面待办盒归档的已完成事项会保存在这里"
-                                           Margin="0,5,0,0"
-                                           Foreground="{DynamicResource TextMutedBrush}"
-                                           FontSize="12.5" />
+                                            Margin="0,4,0,0"
+                                            Foreground="{DynamicResource TextMutedBrush}"
+                                            FontSize="12" />
                             </StackPanel>
                             <Border Grid.Column="1"
                                     VerticalAlignment="Center"
@@ -1225,30 +1727,37 @@
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
 
-                        <StackPanel Grid.Row="0" Margin="0,0,0,10">
-                            <TextBlock Text="Settings"
+                        <StackPanel Grid.Row="0" Margin="0,0,0,7">
+                            <TextBlock Text="设置"
                                        Foreground="{DynamicResource TextMutedBrush}"
-                                       FontSize="12"
-                                       FontWeight="Bold"
+                                       FontSize="11"
+                                       FontWeight="SemiBold"
                                        />
                             <TextBlock Text="系统设置"
                                        Margin="0,2,0,0"
                                        Foreground="{DynamicResource TextPrimaryBrush}"
-                                       FontSize="26"
-                                       FontWeight="Bold" />
+                                       FontSize="24"
+                                       FontWeight="SemiBold" />
                         </StackPanel>
 
-                            <StackPanel Grid.Row="1"
-                                        Margin="0"
+                            <ScrollViewer Grid.Row="1"
+                                          VerticalScrollBarVisibility="Auto"
+                                          HorizontalScrollBarVisibility="Disabled"
+                                          PanningMode="VerticalOnly">
+                                <ScrollViewer.Resources>
+                                    <Style TargetType="{x:Type ScrollBar}"
+                                           BasedOn="{StaticResource DrawerScrollBarStyle}" />
+                                </ScrollViewer.Resources>
+                            <StackPanel Margin="0,0,4,0"
                                         HorizontalAlignment="Stretch"
                                         VerticalAlignment="Top">
                                 <!-- Theme Settings Card -->
                                 <Border Background="{DynamicResource PanelBrush}"
                                     BorderBrush="{DynamicResource BorderBrushSoft}"
                                     BorderThickness="1"
-                                    CornerRadius="14"
-                                    Padding="12"
-                                    Margin="0,0,0,8">
+                                    CornerRadius="12"
+                                    Padding="10"
+                                    Margin="0,0,0,6">
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
@@ -1256,19 +1765,19 @@
                                     </Grid.ColumnDefinitions>
                                     <StackPanel VerticalAlignment="Center">
                                         <TextBlock Text="外观皮肤"
-                                                   FontWeight="Bold"
-                                                   FontSize="14"
+                                                   FontWeight="SemiBold"
+                                                   FontSize="13"
                                                    Foreground="{DynamicResource TextPrimaryBrush}" />
                                         <TextBlock Text="{Binding ThemeLabel, StringFormat=当前风格：{0}}"
-                                                   Margin="0,4,0,0"
-                                                   FontSize="12"
+                                                   Margin="0,2,0,0"
+                                                   FontSize="11.5"
                                                    Foreground="{DynamicResource TextMutedBrush}" />
                                     </StackPanel>
                                     <UniformGrid Grid.Column="1" Columns="3" VerticalAlignment="Center">
                                         <UniformGrid.Resources>
                                             <Style x:Key="ThemeChoiceButtonStyle" TargetType="{x:Type Button}" BasedOn="{StaticResource {x:Type Button}}">
-                                                <Setter Property="Height" Value="30" />
-                                                <Setter Property="Padding" Value="10,2" />
+                                                <Setter Property="Height" Value="28" />
+                                                <Setter Property="Padding" Value="9,2" />
                                                 <Setter Property="FontWeight" Value="Medium" />
                                                 <Setter Property="Template">
                                                     <Setter.Value>
@@ -1395,9 +1904,9 @@
                                 <Border Background="{DynamicResource PanelBrush}"
                                     BorderBrush="{DynamicResource BorderBrushSoft}"
                                     BorderThickness="1"
-                                    CornerRadius="14"
-                                    Padding="12"
-                                    Margin="0,0,0,8">
+                                    CornerRadius="12"
+                                    Padding="10"
+                                    Margin="0,0,0,6">
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
@@ -1405,12 +1914,12 @@
                                     </Grid.ColumnDefinitions>
                                     <StackPanel>
                                         <TextBlock Text="快速呼出面板"
-                                                   FontWeight="Bold"
-                                                   FontSize="14"
+                                                   FontWeight="SemiBold"
+                                                   FontSize="13"
                                                    Foreground="{DynamicResource TextPrimaryBrush}" />
                                         <TextBlock Text="在全局按下快捷键以极速搜索与唤出 WitchDrawer"
-                                                   Margin="0,4,0,0"
-                                                   FontSize="12"
+                                                   Margin="0,2,0,0"
+                                                   FontSize="11.5"
                                                    Foreground="{DynamicResource TextMutedBrush}" />
                                     </StackPanel>
                                     <StackPanel Grid.Column="1"
@@ -1418,8 +1927,8 @@
                                                 VerticalAlignment="Center"
                                                 HorizontalAlignment="Right">
                                         <Button x:Name="QuickPanelHotKeyButton"
-                                                MinWidth="128"
-                                                Height="30"
+                                                 MinWidth="128"
+                                                 Height="28"
                                                 Padding="12,2"
                                                 FontSize="12"
                                                 FontWeight="Bold"
@@ -1445,9 +1954,9 @@
                             <Border Background="{DynamicResource PanelBrush}"
                                     BorderBrush="{DynamicResource BorderBrushSoft}"
                                     BorderThickness="1"
-                                    CornerRadius="14"
-                                    Padding="12"
-                                    Margin="0,0,0,8">
+                                    CornerRadius="12"
+                                    Padding="10"
+                                    Margin="0,0,0,6">
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
@@ -1455,12 +1964,12 @@
                                     </Grid.ColumnDefinitions>
                                     <StackPanel>
                                         <TextBlock Text="检查更新"
-                                                   FontWeight="Bold"
-                                                   FontSize="14"
+                                                   FontWeight="SemiBold"
+                                                   FontSize="13"
                                                    Foreground="{DynamicResource TextPrimaryBrush}" />
                                         <TextBlock Text="{Binding CurrentVersionText}"
-                                                   Margin="0,4,0,0"
-                                                   FontSize="12"
+                                                   Margin="0,2,0,0"
+                                                   FontSize="11.5"
                                                    Foreground="{DynamicResource TextMutedBrush}" />
                                         <TextBlock Text="{Binding UpdateStatusText}"
                                                    Margin="0,2,0,0"
@@ -1470,9 +1979,9 @@
                                     </StackPanel>
                                     <Button Grid.Column="1"
                                             Content="检查更新"
-                                            Command="{Binding CheckForUpdateCommand}"
-                                            Style="{StaticResource PrimaryButtonStyle}"
-                                            Height="30"
+                                             Command="{Binding CheckForUpdateCommand}"
+                                             Style="{StaticResource PrimaryButtonStyle}"
+                                             Height="28"
                                             Padding="12,0"
                                             VerticalAlignment="Center" />
                                 </Grid>
@@ -1482,9 +1991,9 @@
                                 <Border Background="{DynamicResource PanelBrush}"
                                     BorderBrush="{DynamicResource BorderBrushSoft}"
                                     BorderThickness="1"
-                                    CornerRadius="14"
-                                    Padding="12"
-                                    Margin="0,0,0,8">
+                                    CornerRadius="12"
+                                    Padding="10"
+                                    Margin="0,0,0,6">
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
@@ -1492,18 +2001,18 @@
                                     </Grid.ColumnDefinitions>
                                     <StackPanel>
                                         <TextBlock Text="开机自启动"
-                                                   FontWeight="Bold"
-                                                   FontSize="14"
+                                                   FontWeight="SemiBold"
+                                                   FontSize="13"
                                                    Foreground="{DynamicResource TextPrimaryBrush}" />
                                         <TextBlock Text="系统启动时自动运行 WitchDrawer"
-                                                   Margin="0,4,0,0"
-                                                   FontSize="12"
+                                                   Margin="0,2,0,0"
+                                                   FontSize="11.5"
                                                    Foreground="{DynamicResource TextMutedBrush}" />
                                     </StackPanel>
                                     <Button Grid.Column="1"
-                                            Command="{Binding ToggleLaunchOnStartupCommand}"
-                                            VerticalAlignment="Center"
-                                            Height="30"
+                                             Command="{Binding ToggleLaunchOnStartupCommand}"
+                                             VerticalAlignment="Center"
+                                             Height="28"
                                             MinWidth="52"
                                             Padding="12,0">
                                         <Button.Style>
@@ -1564,22 +2073,23 @@
                                 <Border Background="{DynamicResource PanelBrush}"
                                     BorderBrush="{DynamicResource BorderBrushSoft}"
                                     BorderThickness="1"
-                                    CornerRadius="14"
-                                    Padding="12">
+                                    CornerRadius="12"
+                                    Padding="10">
                                 <StackPanel>
                                     <TextBlock Text="桌面微件特性"
-                                               FontWeight="Bold"
-                                               FontSize="14"
+                                               FontWeight="SemiBold"
+                                               FontSize="13"
                                                Foreground="{DynamicResource TextPrimaryBrush}" />
                                     <TextBlock Text="WitchDrawer 桌面收纳栏专为极简桌面开发。仅呈现智能分类图标与轻量投放区，所有多余的标题栏、管理和刷新功能已统一收归本控制台进行操作，以保持您桌面清爽洁净。"
-                                               Margin="0,4,0,0"
-                                               FontSize="12"
-                                               LineHeight="16"
+                                               Margin="0,2,0,0"
+                                               FontSize="11.5"
+                                               LineHeight="15"
                                                TextWrapping="Wrap"
                                                Foreground="{DynamicResource TextMutedBrush}" />
                                 </StackPanel>
                                 </Border>
                             </StackPanel>
+                            </ScrollViewer>
                     </Grid>
 
                     <!-- About Page -->
@@ -1589,16 +2099,16 @@
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
 
-                        <StackPanel Grid.Row="0" Margin="0,0,0,10">
-                            <TextBlock Text="About"
+                        <StackPanel Grid.Row="0" Margin="0,0,0,7">
+                            <TextBlock Text="应用信息"
                                        Foreground="{DynamicResource TextMutedBrush}"
-                                       FontSize="12"
-                                       FontWeight="Bold" />
+                                       FontSize="11"
+                                       FontWeight="SemiBold" />
                             <TextBlock Text="关于"
                                        Margin="0,2,0,0"
                                        Foreground="{DynamicResource TextPrimaryBrush}"
-                                       FontSize="26"
-                                       FontWeight="Bold" />
+                                       FontSize="24"
+                                       FontWeight="SemiBold" />
                         </StackPanel>
 
                             <StackPanel Grid.Row="1"

--- a/src/WitchDrawer.App/MainWindow.xaml.cs
+++ b/src/WitchDrawer.App/MainWindow.xaml.cs
@@ -429,6 +429,13 @@ public partial class MainWindow : Window
             return;
         }
 
+        if (!ViewModel.CanImportFiles)
+        {
+            e.Effects = DragDropEffects.None;
+            e.Handled = true;
+            return;
+        }
+
         e.Effects = e.Data.GetDataPresent(DataFormats.FileDrop) ? DragDropEffects.Move : DragDropEffects.None;
         e.Handled = true;
     }
@@ -443,6 +450,12 @@ public partial class MainWindow : Window
 
         if (!e.Data.GetDataPresent(DataFormats.FileDrop))
         {
+            return;
+        }
+
+        if (!ViewModel.CanImportFiles)
+        {
+            e.Handled = true;
             return;
         }
 

--- a/src/WitchDrawer.App/MainWindow.xaml.cs
+++ b/src/WitchDrawer.App/MainWindow.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media;
+using System.Windows.Media.Animation;
 using WitchDrawer.App.Infrastructure;
 using WitchDrawer.App.ViewModels;
 using WitchDrawer.App.Views;
@@ -33,7 +34,8 @@ public partial class MainWindow : Window
     private Point? _boxDragStart;
     private BoxViewModel? _boxDragSource;
     private ListBoxItem? _boxDropTarget;
-
+    private bool _isBoxVisualStylePageOpen;
+    private bool _isBoxVisualStyleTransitioning;
     public event EventHandler? WindowHidden;
     public event EventHandler? WindowClosing;
     public event EventHandler? DesktopShellRestarted;
@@ -473,6 +475,27 @@ public partial class MainWindow : Window
         if (sender is ListBox listBox && listBox.SelectedItem is not null)
         {
             listBox.ScrollIntoView(listBox.SelectedItem);
+            ShowPrimaryBoxControls();
+            ShowSelectedBoxOverview();
+        }
+    }
+
+    private void OnBoxesPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (e.OriginalSource is not DependencyObject source
+            || ItemsControl.ContainerFromElement(BoxesList, source) is not ListBoxItem)
+        {
+            return;
+        }
+
+        ShowSelectedBoxOverview();
+    }
+
+    private void ShowSelectedBoxOverview()
+    {
+        if (ViewModel.ShowDashboardCommand.CanExecute(null))
+        {
+            ViewModel.ShowDashboardCommand.Execute(null);
         }
     }
 
@@ -642,10 +665,95 @@ public partial class MainWindow : Window
         await ViewModel.CreateMappingBoxCommand.ExecuteAsync(null);
     }
 
-    private async void OnCreatePixelBoxClicked(object sender, RoutedEventArgs e)
+    private void OnOpenBoxVisualStylePage(object sender, RoutedEventArgs e)
     {
-        CreateBoxPopup.IsOpen = false;
-        await ViewModel.CreatePixelBoxCommand.ExecuteAsync(null);
+        if (_isBoxVisualStylePageOpen
+            || _isBoxVisualStyleTransitioning
+            || ViewModel.SelectedBox?.CanSelectVisualStyle != true)
+        {
+            return;
+        }
+
+        _isBoxVisualStylePageOpen = true;
+        BoxControlsPrimaryPanel.IsHitTestVisible = false;
+        BoxVisualStyleSecondaryPanel.IsHitTestVisible = true;
+        VisualStateManager.GoToElementState(
+            BoxControlsPageHost,
+            "VisualStyleSelectionState",
+            useTransitions: true);
+    }
+
+    private void OnCloseBoxVisualStylePage(object sender, RoutedEventArgs e)
+    {
+        ShowPrimaryBoxControls();
+    }
+
+    private async void OnBoxVisualStyleSelected(object sender, RoutedEventArgs e)
+    {
+        if (_isBoxVisualStyleTransitioning
+            || sender is not Button
+            {
+                DataContext: BoxVisualStyleOption option,
+                RenderTransform: ScaleTransform scaleTransform
+            })
+        {
+            return;
+        }
+
+        _isBoxVisualStyleTransitioning = true;
+        BoxVisualStyleSecondaryPanel.IsHitTestVisible = false;
+        try
+        {
+            AnimateVisualStyleSelection(scaleTransform);
+            await Task.Delay(170);
+            await ViewModel.SetSelectedBoxVisualStyleCommand.ExecuteAsync(option);
+            await Task.Delay(40);
+        }
+        catch (Exception exception)
+        {
+            _logger.Error(exception, "Failed to complete box visual style selection animation.");
+        }
+        finally
+        {
+            ShowPrimaryBoxControls();
+            _isBoxVisualStyleTransitioning = false;
+        }
+    }
+
+    private void ShowPrimaryBoxControls()
+    {
+        if (!_isBoxVisualStylePageOpen && !_isBoxVisualStyleTransitioning)
+        {
+            return;
+        }
+
+        _isBoxVisualStylePageOpen = false;
+        BoxVisualStyleSecondaryPanel.IsHitTestVisible = false;
+        BoxControlsPrimaryPanel.IsHitTestVisible = true;
+        VisualStateManager.GoToElementState(
+            BoxControlsPageHost,
+            "PrimaryControlsState",
+            useTransitions: true);
+    }
+
+    private static void AnimateVisualStyleSelection(ScaleTransform scaleTransform)
+    {
+        var easing = new BackEase
+        {
+            Amplitude = 0.3,
+            EasingMode = EasingMode.EaseOut
+        };
+        var pulse = new DoubleAnimation(
+            fromValue: 1,
+            toValue: 1.07,
+            duration: TimeSpan.FromMilliseconds(85))
+        {
+            AutoReverse = true,
+            EasingFunction = easing
+        };
+
+        scaleTransform.BeginAnimation(ScaleTransform.ScaleXProperty, pulse);
+        scaleTransform.BeginAnimation(ScaleTransform.ScaleYProperty, pulse.Clone());
     }
 
     private async void OnCreateTodoBoxClicked(object sender, RoutedEventArgs e)

--- a/src/WitchDrawer.App/Messages/BoxPositionLockStateChangedMessage.cs
+++ b/src/WitchDrawer.App/Messages/BoxPositionLockStateChangedMessage.cs
@@ -1,0 +1,5 @@
+namespace WitchDrawer.App.Messages;
+
+public sealed record BoxPositionLockStateChangedMessage(
+    Guid BoxId,
+    bool IsPositionLocked);

--- a/src/WitchDrawer.App/ViewModels/BoxViewModel.cs
+++ b/src/WitchDrawer.App/ViewModels/BoxViewModel.cs
@@ -51,6 +51,8 @@ public sealed class BoxViewModel : ObservableObject
 
     public BoxType Type => Model.Type;
 
+    public bool IsTodoBox => Type == BoxType.Todo;
+
     public BoxVisualStyle VisualStyle => _visualStyle;
 
     public bool IsPixelStyle => VisualStyle == BoxVisualStyle.Pixel;

--- a/src/WitchDrawer.App/ViewModels/BoxViewModel.cs
+++ b/src/WitchDrawer.App/ViewModels/BoxViewModel.cs
@@ -1,3 +1,4 @@
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using WitchDrawer.App.Messages;
 using WitchDrawer.Core.Abstractions;
@@ -5,14 +6,22 @@ using WitchDrawer.Core.Models;
 
 namespace WitchDrawer.App.ViewModels;
 
-public sealed class BoxViewModel
+public sealed class BoxViewModel : ObservableObject
 {
     private readonly IDrawerService _drawerService;
+    private BoxVisualStyle _visualStyle;
+    private bool _isPositionLocked;
 
-    public BoxViewModel(Box model, IDrawerService drawerService)
+    public BoxViewModel(
+        Box model,
+        IDrawerService drawerService,
+        BoxVisualStyle visualStyle,
+        bool isPositionLocked)
     {
         Model = model;
         _drawerService = drawerService;
+        _visualStyle = visualStyle;
+        _isPositionLocked = isPositionLocked;
 
         LayoutSettings = new DesktopBoxLayoutSettings();
         LayoutSettings.SetPresetChangedCallback(async (preset) => 
@@ -42,29 +51,42 @@ public sealed class BoxViewModel
 
     public BoxType Type => Model.Type;
 
+    public BoxVisualStyle VisualStyle => _visualStyle;
+
+    public bool IsPixelStyle => VisualStyle == BoxVisualStyle.Pixel;
+
+    public bool CanSelectVisualStyle => Type is BoxType.Normal or BoxType.Pixel;
+
+    public bool IsPositionLocked => _isPositionLocked;
+
+    public string PositionLockButtonToolTip =>
+        IsPositionLocked ? "解锁桌面位置" : "锁定桌面位置";
+
+    public string PositionLockButtonAutomationName =>
+        IsPositionLocked ? "解锁当前收纳盒桌面位置" : "锁定当前收纳盒桌面位置";
+
+    public string VisualStyleLabel => BoxVisualStyleCatalog.GetOption(VisualStyle).Name;
+
     public string TypeLabel => Model.Type switch
     {
-        BoxType.Normal => "普通",
+        BoxType.Normal or BoxType.Pixel => "普通",
         BoxType.Mapping => "映射",
-        BoxType.Pixel => "像素",
         BoxType.Todo => "待办",
         _ => "未知"
     };
 
     public string Description => Model.Type switch
     {
-        BoxType.Normal => "拖入后移动到收纳盒",
+        BoxType.Normal or BoxType.Pixel => "拖入后移动到收纳盒",
         BoxType.Mapping => "只保存路径引用",
-        BoxType.Pixel => "像素艺术风格收纳",
         BoxType.Todo => "独立桌面待办清单",
         _ => string.Empty
     };
 
     public string Badge => Model.Type switch
     {
-        BoxType.Normal => "N",
+        BoxType.Normal or BoxType.Pixel => "N",
         BoxType.Mapping => "M",
-        BoxType.Pixel => "P",
         BoxType.Todo => "T",
         _ => "?"
     };
@@ -82,5 +104,32 @@ public sealed class BoxViewModel
         BoxType.Mapping => "只会移除映射引用，源文件不会被移动或删除。",
         _ => "收纳盒内的文件将恢复到原来的位置；如有重名会自动加后缀。"
     };
+
+    public void ApplyVisualStyle(BoxVisualStyle visualStyle)
+    {
+        if (_visualStyle == visualStyle)
+        {
+            return;
+        }
+
+        _visualStyle = visualStyle;
+        OnPropertyChanged(nameof(VisualStyle));
+        OnPropertyChanged(nameof(IsPixelStyle));
+        OnPropertyChanged(nameof(VisualStyleLabel));
+    }
+
+    public void ApplyPositionLockState(bool isPositionLocked)
+    {
+        if (!SetProperty(
+                ref _isPositionLocked,
+                isPositionLocked,
+                nameof(IsPositionLocked)))
+        {
+            return;
+        }
+
+        OnPropertyChanged(nameof(PositionLockButtonToolTip));
+        OnPropertyChanged(nameof(PositionLockButtonAutomationName));
+    }
 }
 

--- a/src/WitchDrawer.App/ViewModels/BoxVisualStyle.cs
+++ b/src/WitchDrawer.App/ViewModels/BoxVisualStyle.cs
@@ -1,0 +1,7 @@
+namespace WitchDrawer.App.ViewModels;
+
+public enum BoxVisualStyle
+{
+    Modern = 0,
+    Pixel = 1
+}

--- a/src/WitchDrawer.App/ViewModels/BoxVisualStyleCatalog.cs
+++ b/src/WitchDrawer.App/ViewModels/BoxVisualStyleCatalog.cs
@@ -1,0 +1,28 @@
+namespace WitchDrawer.App.ViewModels;
+
+public static class BoxVisualStyleCatalog
+{
+    public static IReadOnlyList<BoxVisualStyleOption> Options { get; } =
+    [
+        new(
+            BoxVisualStyle.Modern,
+            "现代图标",
+            "清晰圆润，适合日常桌面",
+            "\uE8B7"),
+        new(
+            BoxVisualStyle.Pixel,
+            "像素图标",
+            "复古像素边缘与点阵细节",
+            "\uE7C4")
+    ];
+
+    public static bool IsSupported(BoxVisualStyle style)
+    {
+        return Options.Any(option => option.Style == style);
+    }
+
+    public static BoxVisualStyleOption GetOption(BoxVisualStyle style)
+    {
+        return Options.First(option => option.Style == style);
+    }
+}

--- a/src/WitchDrawer.App/ViewModels/BoxVisualStyleOption.cs
+++ b/src/WitchDrawer.App/ViewModels/BoxVisualStyleOption.cs
@@ -1,0 +1,7 @@
+namespace WitchDrawer.App.ViewModels;
+
+public sealed record BoxVisualStyleOption(
+    BoxVisualStyle Style,
+    string Name,
+    string Description,
+    string Glyph);

--- a/src/WitchDrawer.App/ViewModels/DesktopBoxViewModel.cs
+++ b/src/WitchDrawer.App/ViewModels/DesktopBoxViewModel.cs
@@ -24,6 +24,7 @@ public sealed class DesktopBoxViewModel : ObservableObject
     private readonly IAppLogger _logger;
     private readonly DesktopBoxLayoutSettings _layoutSettings;
     private Box _box;
+    private BoxVisualStyle _visualStyle;
     private bool _isBusy;
     private double _gridCanvasWidth;
     private double _gridCanvasHeight;
@@ -45,9 +46,11 @@ public sealed class DesktopBoxViewModel : ObservableObject
         ITodoService todoService,
         IFileLauncher launcher,
         IAppLogger logger,
+        BoxVisualStyle visualStyle,
         DesktopBoxLayoutSettings? layoutSettings = null)
     {
         _box = box;
+        _visualStyle = visualStyle;
         _drawerService = drawerService;
         _todoService = todoService;
         _launcher = launcher;
@@ -100,6 +103,10 @@ public sealed class DesktopBoxViewModel : ObservableObject
 
     public BoxType Type => _box.Type;
 
+    public BoxVisualStyle VisualStyle => _visualStyle;
+
+    public bool IsPixelStyle => VisualStyle == BoxVisualStyle.Pixel;
+
     public bool IsMappingBox => Type == BoxType.Mapping;
 
     public bool IsTodoBox => Type == BoxType.Todo;
@@ -110,18 +117,16 @@ public sealed class DesktopBoxViewModel : ObservableObject
 
     public string TypeLabel => _box.Type switch
     {
-        BoxType.Normal => "普通",
+        BoxType.Normal or BoxType.Pixel => "普通",
         BoxType.Mapping => "映射",
-        BoxType.Pixel => "像素",
         BoxType.Todo => "待办",
         _ => "未知"
     };
 
     public string Description => _box.Type switch
     {
-        BoxType.Normal => "移动收纳",
+        BoxType.Normal or BoxType.Pixel => "移动收纳",
         BoxType.Mapping => "路径映射",
-        BoxType.Pixel => "像素收纳",
         BoxType.Todo => "桌面待办",
         _ => string.Empty
     };
@@ -200,11 +205,14 @@ public sealed class DesktopBoxViewModel : ObservableObject
         private set => SetProperty(ref _statusText, value);
     }
 
-    public void UpdateBox(Box box)
+    public void UpdateBox(Box box, BoxVisualStyle visualStyle)
     {
         _box = box;
+        _visualStyle = visualStyle;
         OnPropertyChanged(nameof(Name));
         OnPropertyChanged(nameof(Type));
+        OnPropertyChanged(nameof(VisualStyle));
+        OnPropertyChanged(nameof(IsPixelStyle));
         OnPropertyChanged(nameof(IsMappingBox));
         OnPropertyChanged(nameof(IsTodoBox));
         OnPropertyChanged(nameof(IsMappingListMode));
@@ -335,7 +343,7 @@ public sealed class DesktopBoxViewModel : ObservableObject
             // before the window is created so boxes can use different icon sizes.
 
             var items = await _drawerService.GetItemsAsync(BoxId);
-            var isPixelated = Type == BoxType.Pixel;
+            var isPixelated = IsPixelStyle;
             var positions = ResolveItemPositions(items);
 
             var existingIds = new HashSet<Guid>();
@@ -836,7 +844,7 @@ public sealed class DesktopBoxViewModel : ObservableObject
 
     private void UpdateItemIconSizes()
     {
-        var iconPixelSize = GetIconPixelSize(Type == BoxType.Pixel);
+        var iconPixelSize = GetIconPixelSize(IsPixelStyle);
         foreach (var item in Items)
         {
             item.RequestIconSize(iconPixelSize);

--- a/src/WitchDrawer.App/ViewModels/MainViewModel.cs
+++ b/src/WitchDrawer.App/ViewModels/MainViewModel.cs
@@ -63,6 +63,8 @@ public sealed class MainViewModel : ObservableObject
         _updateService = updateService;
         _boxVisualStyleStore = boxVisualStyleStore;
         _boxPositionLockStateStore = boxPositionLockStateStore;
+        TodoBoxDetail = new TodoBoxDetailViewModel(todoService, logger);
+        TodoBoxDetail.ItemsChanged += OnTodoBoxDetailItemsChanged;
 
         LoadCommand = new AsyncRelayCommand(LoadAsync);
         CreateNormalBoxCommand = new AsyncRelayCommand(
@@ -124,6 +126,8 @@ public sealed class MainViewModel : ObservableObject
     public ObservableCollection<DrawerItemViewModel> Items { get; } = [];
 
     public ObservableCollection<ArchivedTodoItemViewModel> ArchivedTodos { get; } = [];
+
+    public TodoBoxDetailViewModel TodoBoxDetail { get; }
 
     public IReadOnlyList<BoxVisualStyleOption> BoxVisualStyleOptions =>
         BoxVisualStyleCatalog.Options;
@@ -196,6 +200,10 @@ public sealed class MainViewModel : ObservableObject
             }
         }
     }
+
+    public bool IsSelectedTodoBox => SelectedBox?.IsTodoBox == true;
+
+    public bool CanImportFiles => SelectedBox is { IsTodoBox: false };
 
     public bool IsBusy
     {
@@ -399,6 +407,12 @@ public sealed class MainViewModel : ObservableObject
         if (selectedBox is null)
         {
             StatusText = "请先选择一个收纳盒";
+            return;
+        }
+
+        if (selectedBox.IsTodoBox)
+        {
+            StatusText = "待办收纳盒请使用任务输入框添加事项";
             return;
         }
 
@@ -630,6 +644,8 @@ public sealed class MainViewModel : ObservableObject
 
         _selectedBox = value;
         OnPropertyChanged(nameof(SelectedBox));
+        OnPropertyChanged(nameof(IsSelectedTodoBox));
+        OnPropertyChanged(nameof(CanImportFiles));
         DeleteSelectedBoxCommand.NotifyCanExecuteChanged();
         RenameSelectedBoxCommand.NotifyCanExecuteChanged();
         SetSelectedBoxVisualStyleCommand.NotifyCanExecuteChanged();
@@ -676,6 +692,18 @@ public sealed class MainViewModel : ObservableObject
         int version,
         CancellationToken cancellationToken)
     {
+        if (selectedBox?.IsTodoBox == true)
+        {
+            if (IsCurrentItemsLoad(selectedBox, version))
+            {
+                Items.Clear();
+            }
+
+            await TodoBoxDetail.LoadAsync(selectedBox.Id);
+            return;
+        }
+
+        await TodoBoxDetail.LoadAsync(null);
         if (selectedBox is null)
         {
             if (IsCurrentItemsLoad(null, version))
@@ -788,6 +816,11 @@ public sealed class MainViewModel : ObservableObject
         {
             await _todoService.RestoreArchivedAsync(todo.Id);
             await LoadArchivedTodosAsync();
+            if (SelectedBox?.Id == todo.Model.BoxId)
+            {
+                await TodoBoxDetail.LoadAsync(todo.Model.BoxId);
+            }
+
             StatusText = $"已将“{todo.Title}”恢复到 {todo.BoxName}";
             ItemsChanged?.Invoke(this, EventArgs.Empty);
         });
@@ -827,6 +860,12 @@ public sealed class MainViewModel : ObservableObject
             _logger.Error(exception, "Failed to load archived todos.");
             StatusText = exception.Message;
         }
+    }
+
+    private void OnTodoBoxDetailItemsChanged(object? sender, EventArgs e)
+    {
+        StatusText = TodoBoxDetail.StatusText;
+        ItemsChanged?.Invoke(this, EventArgs.Empty);
     }
 
     private async Task ApplyThemeAsync(AppTheme theme)

--- a/src/WitchDrawer.App/ViewModels/MainViewModel.cs
+++ b/src/WitchDrawer.App/ViewModels/MainViewModel.cs
@@ -2,7 +2,9 @@ using System.Collections.ObjectModel;
 using System.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using WitchDrawer.App.Infrastructure;
+using WitchDrawer.App.Messages;
 using WitchDrawer.Core.Abstractions;
 using WitchDrawer.Core.Logging;
 using WitchDrawer.Core.Models;
@@ -23,6 +25,8 @@ public sealed class MainViewModel : ObservableObject
     private readonly IAppLogger _logger;
     private readonly QuickPanelViewModel _quickPanelViewModel;
     private readonly IUpdateService _updateService;
+    private readonly BoxVisualStyleStore _boxVisualStyleStore;
+    private readonly BoxPositionLockStateStore _boxPositionLockStateStore;
     private BoxViewModel? _selectedBox;
     private CancellationTokenSource? _itemsLoadCts;
     private int _itemsLoadVersion;
@@ -47,7 +51,9 @@ public sealed class MainViewModel : ObservableObject
         IFileLauncher launcher,
         IAppLogger logger,
         QuickPanelViewModel quickPanelViewModel,
-        IUpdateService updateService)
+        IUpdateService updateService,
+        BoxVisualStyleStore boxVisualStyleStore,
+        BoxPositionLockStateStore boxPositionLockStateStore)
     {
         _drawerService = drawerService;
         _todoService = todoService;
@@ -55,11 +61,25 @@ public sealed class MainViewModel : ObservableObject
         _logger = logger;
         _quickPanelViewModel = quickPanelViewModel;
         _updateService = updateService;
+        _boxVisualStyleStore = boxVisualStyleStore;
+        _boxPositionLockStateStore = boxPositionLockStateStore;
 
         LoadCommand = new AsyncRelayCommand(LoadAsync);
-        CreateNormalBoxCommand = new AsyncRelayCommand(() => CreateBoxAsync(BoxType.Normal));
+        CreateNormalBoxCommand = new AsyncRelayCommand(
+            () => CreateBoxAsync(BoxType.Normal, BoxVisualStyle.Modern));
         CreateMappingBoxCommand = new AsyncRelayCommand(() => CreateBoxAsync(BoxType.Mapping));
-        CreatePixelBoxCommand = new AsyncRelayCommand(() => CreateBoxAsync(BoxType.Pixel));
+        CreatePixelBoxCommand = new AsyncRelayCommand(
+            () => CreateBoxAsync(BoxType.Normal, BoxVisualStyle.Pixel));
+        CreateStyledNormalBoxCommand =
+            new AsyncRelayCommand<BoxVisualStyleOption?>(CreateStyledNormalBoxAsync);
+        SetSelectedBoxVisualStyleCommand =
+            new AsyncRelayCommand<BoxVisualStyleOption?>(
+                SetSelectedBoxVisualStyleAsync,
+                option => option is not null && SelectedBox?.CanSelectVisualStyle == true);
+        ToggleSelectedBoxPositionLockCommand =
+            new AsyncRelayCommand(
+                ToggleSelectedBoxPositionLockAsync,
+                () => SelectedBox is not null);
         CreateTodoBoxCommand = new AsyncRelayCommand(() => CreateBoxAsync(BoxType.Todo));
         DeleteSelectedBoxCommand = new AsyncRelayCommand(DeleteSelectedBoxAsync, () => SelectedBox is not null);
         RenameSelectedBoxCommand = new AsyncRelayCommand<string?>(RenameSelectedBoxAsync, _ => SelectedBox is not null);
@@ -105,6 +125,9 @@ public sealed class MainViewModel : ObservableObject
 
     public ObservableCollection<ArchivedTodoItemViewModel> ArchivedTodos { get; } = [];
 
+    public IReadOnlyList<BoxVisualStyleOption> BoxVisualStyleOptions =>
+        BoxVisualStyleCatalog.Options;
+
     public void UpdateIconDisplayMetrics(double dpiScaleX, double dpiScaleY)
     {
         _iconDpiScaleX = NormalizeDpiScale(dpiScaleX);
@@ -123,6 +146,12 @@ public sealed class MainViewModel : ObservableObject
     public IAsyncRelayCommand CreateMappingBoxCommand { get; }
 
     public IAsyncRelayCommand CreatePixelBoxCommand { get; }
+
+    public IAsyncRelayCommand<BoxVisualStyleOption?> CreateStyledNormalBoxCommand { get; }
+
+    public IAsyncRelayCommand<BoxVisualStyleOption?> SetSelectedBoxVisualStyleCommand { get; }
+
+    public IAsyncRelayCommand ToggleSelectedBoxPositionLockCommand { get; }
 
     public IAsyncRelayCommand CreateTodoBoxCommand { get; }
 
@@ -269,11 +298,16 @@ public sealed class MainViewModel : ObservableObject
         {
             var existingSelection = SelectedBox?.Id;
             var boxes = await _drawerService.GetBoxesAsync();
+            var presentedBoxes = await LoadBoxPresentationAsync(boxes);
 
             Boxes.Clear();
-            foreach (var box in boxes)
+            foreach (var (box, visualStyle, isPositionLocked) in presentedBoxes)
             {
-                Boxes.Add(new BoxViewModel(box, _drawerService));
+                Boxes.Add(new BoxViewModel(
+                    box,
+                    _drawerService,
+                    visualStyle,
+                    isPositionLocked));
             }
 
             await SelectBoxAsync(Boxes.FirstOrDefault(box => box.Id == existingSelection) ?? Boxes.FirstOrDefault());
@@ -390,7 +424,16 @@ public sealed class MainViewModel : ObservableObject
         });
     }
 
-    private async Task CreateBoxAsync(BoxType type)
+    private Task CreateStyledNormalBoxAsync(BoxVisualStyleOption? option)
+    {
+        return option is null
+            ? Task.CompletedTask
+            : CreateBoxAsync(BoxType.Normal, option.Style);
+    }
+
+    private async Task CreateBoxAsync(
+        BoxType type,
+        BoxVisualStyle? visualStyle = null)
     {
         await RunBusyAsync(async () =>
         {
@@ -402,14 +445,112 @@ public sealed class MainViewModel : ObservableObject
                 BoxType.Todo => "待办收纳盒",
                 _ => "收纳盒"
             };
-            var name = $"{prefix} {Boxes.Count(box => box.Type == type) + 1}";
+            var matchingBoxCount = type == BoxType.Normal
+                ? Boxes.Count(box => box.Type is BoxType.Normal or BoxType.Pixel)
+                : Boxes.Count(box => box.Type == type);
+            var name = $"{prefix} {matchingBoxCount + 1}";
             var box = await _drawerService.CreateBoxAsync(name, type);
-            var viewModel = new BoxViewModel(box, _drawerService);
+            var effectiveStyle = visualStyle ?? BoxVisualStyle.Modern;
+            if (type == BoxType.Normal)
+            {
+                try
+                {
+                    await _boxVisualStyleStore.SaveAsync(box.Id, effectiveStyle);
+                }
+                catch
+                {
+                    await CompensateFailedStyledBoxCreationAsync(box.Id);
+                    throw;
+                }
+            }
+
+            var viewModel = new BoxViewModel(
+                box,
+                _drawerService,
+                effectiveStyle,
+                isPositionLocked: false);
             Boxes.Add(viewModel);
             await SelectBoxAsync(viewModel);
             StatusText = $"已创建 {name}，桌面收纳栏已生成";
             BoxesChanged?.Invoke(this, EventArgs.Empty);
         });
+    }
+
+    private async Task SetSelectedBoxVisualStyleAsync(BoxVisualStyleOption? option)
+    {
+        var selectedBox = SelectedBox;
+        if (option is null || selectedBox?.CanSelectVisualStyle != true)
+        {
+            return;
+        }
+
+        await RunBusyAsync(async () =>
+        {
+            await _boxVisualStyleStore.SaveAsync(selectedBox.Id, option.Style);
+            selectedBox.ApplyVisualStyle(option.Style);
+            await LoadItemsForSelectedBoxAsync(selectedBox);
+            await _quickPanelViewModel.LoadAsync();
+            StatusText = $"已将“{selectedBox.Name}”切换为{option.Name}";
+            BoxesChanged?.Invoke(this, EventArgs.Empty);
+        });
+    }
+
+    private async Task ToggleSelectedBoxPositionLockAsync()
+    {
+        var selectedBox = SelectedBox;
+        if (selectedBox is null)
+        {
+            return;
+        }
+
+        await RunBusyAsync(async () =>
+        {
+            var isPositionLocked = !selectedBox.IsPositionLocked;
+            await _boxPositionLockStateStore.SaveAsync(
+                selectedBox.Id,
+                isPositionLocked);
+            selectedBox.ApplyPositionLockState(isPositionLocked);
+            WeakReferenceMessenger.Default.Send(
+                new BoxPositionLockStateChangedMessage(
+                    selectedBox.Id,
+                    isPositionLocked));
+            StatusText = isPositionLocked
+                ? $"已锁定“{selectedBox.Name}”的桌面位置"
+                : $"已解锁“{selectedBox.Name}”的桌面位置";
+        });
+    }
+
+    private async Task CompensateFailedStyledBoxCreationAsync(Guid boxId)
+    {
+        try
+        {
+            await _drawerService.DeleteBoxAsync(boxId);
+            _logger.Info(
+                $"Removed empty box {boxId:N} after visual style persistence failed.");
+        }
+        catch (Exception compensationException)
+        {
+            _logger.Error(
+                compensationException,
+                $"Failed to remove empty box {boxId:N} after visual style persistence failed.");
+        }
+    }
+
+    private async Task<(Box Box, BoxVisualStyle VisualStyle, bool IsPositionLocked)[]> LoadBoxPresentationAsync(
+        IReadOnlyList<Box> boxes)
+    {
+        return await Task.WhenAll(
+            boxes.Select(async box =>
+            {
+                var visualStyleTask = _boxVisualStyleStore.LoadAsync(box);
+                var positionLockStateTask =
+                    _boxPositionLockStateStore.LoadAsync(box.Id);
+                await Task.WhenAll(visualStyleTask, positionLockStateTask);
+                return (
+                    box,
+                    await visualStyleTask,
+                    await positionLockStateTask);
+            }));
     }
 
     private async Task DeleteSelectedBoxAsync()
@@ -425,10 +566,15 @@ public sealed class MainViewModel : ObservableObject
             var result = await _drawerService.DeleteBoxAsync(selectedBox.Id);
 
             var boxes = await _drawerService.GetBoxesAsync();
+            var presentedBoxes = await LoadBoxPresentationAsync(boxes);
             Boxes.Clear();
-            foreach (var box in boxes)
+            foreach (var (box, visualStyle, isPositionLocked) in presentedBoxes)
             {
-                Boxes.Add(new BoxViewModel(box, _drawerService));
+                Boxes.Add(new BoxViewModel(
+                    box,
+                    _drawerService,
+                    visualStyle,
+                    isPositionLocked));
             }
 
             await SelectBoxAsync(
@@ -456,10 +602,15 @@ public sealed class MainViewModel : ObservableObject
             await _drawerService.RenameBoxAsync(selectedBox.Id, newName);
 
             var boxes = await _drawerService.GetBoxesAsync();
+            var presentedBoxes = await LoadBoxPresentationAsync(boxes);
             Boxes.Clear();
-            foreach (var box in boxes)
+            foreach (var (box, visualStyle, isPositionLocked) in presentedBoxes)
             {
-                Boxes.Add(new BoxViewModel(box, _drawerService));
+                Boxes.Add(new BoxViewModel(
+                    box,
+                    _drawerService,
+                    visualStyle,
+                    isPositionLocked));
             }
 
             await SelectBoxAsync(Boxes.FirstOrDefault(b => b.Id == selectedBox.Id) ?? Boxes.FirstOrDefault());
@@ -481,6 +632,8 @@ public sealed class MainViewModel : ObservableObject
         OnPropertyChanged(nameof(SelectedBox));
         DeleteSelectedBoxCommand.NotifyCanExecuteChanged();
         RenameSelectedBoxCommand.NotifyCanExecuteChanged();
+        SetSelectedBoxVisualStyleCommand.NotifyCanExecuteChanged();
+        ToggleSelectedBoxPositionLockCommand.NotifyCanExecuteChanged();
         return true;
     }
 
@@ -543,7 +696,7 @@ public sealed class MainViewModel : ObservableObject
                 return;
             }
 
-            var isPixelated = selectedBox.Type == BoxType.Pixel;
+            var isPixelated = selectedBox.IsPixelStyle;
             Items.Clear();
             foreach (var item in items)
             {

--- a/src/WitchDrawer.App/ViewModels/QuickPanelViewModel.cs
+++ b/src/WitchDrawer.App/ViewModels/QuickPanelViewModel.cs
@@ -16,17 +16,23 @@ public sealed class QuickPanelViewModel : ObservableObject
     private readonly IDrawerService _drawerService;
     private readonly IFileLauncher _launcher;
     private readonly IAppLogger _logger;
+    private readonly BoxVisualStyleStore _boxVisualStyleStore;
     private List<DrawerItemViewModel> _allItems = [];
     private string _searchText = string.Empty;
     private double _iconDpiScaleX = 1;
     private double _iconDpiScaleY = 1;
     private string _statusText = "快速面板";
 
-    public QuickPanelViewModel(IDrawerService drawerService, IFileLauncher launcher, IAppLogger logger)
+    public QuickPanelViewModel(
+        IDrawerService drawerService,
+        IFileLauncher launcher,
+        IAppLogger logger,
+        BoxVisualStyleStore boxVisualStyleStore)
     {
         _drawerService = drawerService;
         _launcher = launcher;
         _logger = logger;
+        _boxVisualStyleStore = boxVisualStyleStore;
         OpenItemCommand = new AsyncRelayCommand<DrawerItemViewModel?>(OpenItemAsync);
     }
 
@@ -69,13 +75,20 @@ public sealed class QuickPanelViewModel : ObservableObject
         {
             var boxes = await _drawerService.GetBoxesAsync();
             var boxesById = boxes.ToDictionary(box => box.Id);
+            var boxStyles = await Task.WhenAll(
+                boxes.Select(async box =>
+                    (box.Id, Style: await _boxVisualStyleStore.LoadAsync(box))));
+            var stylesByBoxId = boxStyles.ToDictionary(entry => entry.Id, entry => entry.Style);
             var items = await _drawerService.GetAllItemsAsync();
 
             _allItems = items
                 .Select(item =>
                 {
                     boxesById.TryGetValue(item.BoxId, out var box);
-                    var isPixelated = box?.Type == BoxType.Pixel;
+                    var isPixelated = stylesByBoxId.TryGetValue(
+                        item.BoxId,
+                        out var visualStyle)
+                        && visualStyle == BoxVisualStyle.Pixel;
                     return new DrawerItemViewModel(
                         item,
                         box?.Name ?? string.Empty,

--- a/src/WitchDrawer.App/ViewModels/TodoBoxDetailViewModel.cs
+++ b/src/WitchDrawer.App/ViewModels/TodoBoxDetailViewModel.cs
@@ -1,0 +1,365 @@
+using System.Collections.ObjectModel;
+using System.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using WitchDrawer.Core.Logging;
+using WitchDrawer.Core.Services;
+
+namespace WitchDrawer.App.ViewModels;
+
+public sealed class TodoBoxDetailViewModel : ObservableObject
+{
+    private readonly TodoService _todoService;
+    private readonly IAppLogger _logger;
+    private CancellationTokenSource? _loadCts;
+    private int _loadVersion;
+    private Guid? _boxId;
+    private string _newTodoTitle = string.Empty;
+    private string _statusText = "从一件小事开始";
+    private bool _isBusy;
+
+    public TodoBoxDetailViewModel(
+        TodoService todoService,
+        IAppLogger logger)
+    {
+        _todoService = todoService;
+        _logger = logger;
+
+        AddTodoCommand = new AsyncRelayCommand(AddTodoAsync, CanAddTodo);
+        ToggleTodoCommand = new AsyncRelayCommand<TodoItemViewModel?>(ToggleTodoAsync);
+        DeleteTodoCommand = new AsyncRelayCommand<TodoItemViewModel?>(DeleteTodoAsync);
+        ArchiveCompletedCommand = new AsyncRelayCommand(
+            ArchiveCompletedAsync,
+            CanArchiveCompleted);
+    }
+
+    public event EventHandler? ItemsChanged;
+
+    public ObservableCollection<TodoItemViewModel> ActiveTodos { get; } = [];
+
+    public ObservableCollection<TodoItemViewModel> CompletedTodos { get; } = [];
+
+    public IAsyncRelayCommand AddTodoCommand { get; }
+
+    public IAsyncRelayCommand<TodoItemViewModel?> ToggleTodoCommand { get; }
+
+    public IAsyncRelayCommand<TodoItemViewModel?> DeleteTodoCommand { get; }
+
+    public IAsyncRelayCommand ArchiveCompletedCommand { get; }
+
+    public Guid? BoxId
+    {
+        get => _boxId;
+        private set
+        {
+            if (SetProperty(ref _boxId, value))
+            {
+                NotifyCommandStateChanged();
+            }
+        }
+    }
+
+    public string NewTodoTitle
+    {
+        get => _newTodoTitle;
+        set
+        {
+            if (SetProperty(ref _newTodoTitle, value))
+            {
+                AddTodoCommand.NotifyCanExecuteChanged();
+            }
+        }
+    }
+
+    public string StatusText
+    {
+        get => _statusText;
+        private set => SetProperty(ref _statusText, value);
+    }
+
+    public bool IsBusy
+    {
+        get => _isBusy;
+        private set
+        {
+            if (SetProperty(ref _isBusy, value))
+            {
+                NotifyCommandStateChanged();
+            }
+        }
+    }
+
+    public int RemainingCount => ActiveTodos.Count;
+
+    public int CompletedCount => CompletedTodos.Count;
+
+    public int TotalCount => RemainingCount + CompletedCount;
+
+    public int CompletionPercentage =>
+        TotalCount == 0
+            ? 0
+            : (int)Math.Round(
+                CompletedCount * 100d / TotalCount,
+                MidpointRounding.AwayFromZero);
+
+    public bool IsEmpty => TotalCount == 0;
+
+    public bool HasActiveTodos => RemainingCount > 0;
+
+    public bool HasCompletedTodos => CompletedCount > 0;
+
+    public async Task LoadAsync(Guid? boxId)
+    {
+        _loadCts?.Cancel();
+        _loadCts?.Dispose();
+        _loadCts = new CancellationTokenSource();
+        var cancellationToken = _loadCts.Token;
+        var version = Interlocked.Increment(ref _loadVersion);
+
+        if (BoxId != boxId)
+        {
+            BoxId = boxId;
+            NewTodoTitle = string.Empty;
+        }
+
+        if (boxId is null)
+        {
+            ReplaceItems([]);
+            StatusText = "选择一个待办收纳盒";
+            IsBusy = false;
+            return;
+        }
+
+        IsBusy = true;
+        try
+        {
+            var todos = await _todoService.GetTodosAsync(
+                boxId.Value,
+                cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!IsCurrentLoad(boxId.Value, version))
+            {
+                return;
+            }
+
+            ReplaceItems(todos.Select(todo => new TodoItemViewModel(todo)));
+            StatusText = IsEmpty
+                ? "从一件小事开始"
+                : $"{RemainingCount} 项待完成";
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            if (!IsCurrentLoad(boxId.Value, version))
+            {
+                return;
+            }
+
+            _logger.Error(
+                exception,
+                $"Failed to load todo box {boxId.Value:N} in the main workspace.");
+            StatusText = exception.Message;
+        }
+        finally
+        {
+            if (IsCurrentLoad(boxId.Value, version))
+            {
+                IsBusy = false;
+            }
+        }
+    }
+
+    private bool CanAddTodo()
+    {
+        var normalizedTitle = NewTodoTitle.Trim();
+        return BoxId is not null
+            && !IsBusy
+            && normalizedTitle.Length is > 0 and <= TodoService.MaximumTitleLength;
+    }
+
+    private async Task AddTodoAsync()
+    {
+        var boxId = BoxId;
+        var title = NewTodoTitle;
+        if (boxId is null)
+        {
+            return;
+        }
+
+        await RunMutationAsync(
+            boxId.Value,
+            "add",
+            async () =>
+            {
+                var added = await _todoService.AddTodoAsync(boxId.Value, title);
+                _logger.Info(
+                    $"Todo detail add completed. BoxId={boxId.Value:N}; TodoId={added.Id:N}.");
+                if (BoxId == boxId)
+                {
+                    NewTodoTitle = string.Empty;
+                }
+
+                return "已添加待办";
+            });
+    }
+
+    private async Task ToggleTodoAsync(TodoItemViewModel? todo)
+    {
+        var boxId = BoxId;
+        if (boxId is null || todo is null || todo.Model.BoxId != boxId.Value)
+        {
+            return;
+        }
+
+        var targetState = !todo.IsCompleted;
+        await RunMutationAsync(
+            boxId.Value,
+            targetState ? "complete" : "reopen",
+            async () =>
+            {
+                await _todoService.SetCompletedAsync(todo.Id, targetState);
+                _logger.Info(
+                    $"Todo detail completion changed. BoxId={boxId.Value:N}; TodoId={todo.Id:N}; IsCompleted={targetState}.");
+                return targetState ? "完成一项，做得不错" : "已恢复为待完成";
+            });
+    }
+
+    private async Task DeleteTodoAsync(TodoItemViewModel? todo)
+    {
+        var boxId = BoxId;
+        if (boxId is null || todo is null || todo.Model.BoxId != boxId.Value)
+        {
+            return;
+        }
+
+        await RunMutationAsync(
+            boxId.Value,
+            "delete",
+            async () =>
+            {
+                await _todoService.DeleteTodoAsync(todo.Id);
+                _logger.Info(
+                    $"Todo detail delete completed. BoxId={boxId.Value:N}; TodoId={todo.Id:N}.");
+                return "已删除待办";
+            });
+    }
+
+    private bool CanArchiveCompleted()
+    {
+        return BoxId is not null && !IsBusy && HasCompletedTodos;
+    }
+
+    private async Task ArchiveCompletedAsync()
+    {
+        var boxId = BoxId;
+        if (boxId is null)
+        {
+            return;
+        }
+
+        await RunMutationAsync(
+            boxId.Value,
+            "archive",
+            async () =>
+            {
+                var archivedCount = await _todoService.ArchiveCompletedAsync(
+                    boxId.Value);
+                _logger.Info(
+                    $"Todo detail archive completed. BoxId={boxId.Value:N}; Count={archivedCount}.");
+                return archivedCount == 0
+                    ? "没有可归档的事项"
+                    : $"已归档 {archivedCount} 项";
+            });
+    }
+
+    private async Task RunMutationAsync(
+        Guid boxId,
+        string operation,
+        Func<Task<string>> mutate)
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        _logger.Info(
+            $"Todo detail mutation started. Operation={operation}; BoxId={boxId:N}.");
+        try
+        {
+            var statusText = await mutate();
+            await ReloadAfterMutationAsync(boxId);
+            if (BoxId == boxId)
+            {
+                StatusText = statusText;
+            }
+
+            ItemsChanged?.Invoke(this, EventArgs.Empty);
+        }
+        catch (Exception exception)
+        {
+            _logger.Error(
+                exception,
+                $"Todo detail mutation failed. Operation={operation}; BoxId={boxId:N}.");
+            if (BoxId == boxId)
+            {
+                StatusText = exception.Message;
+            }
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private async Task ReloadAfterMutationAsync(Guid boxId)
+    {
+        var todos = await _todoService.GetTodosAsync(boxId);
+        if (BoxId != boxId)
+        {
+            return;
+        }
+
+        ReplaceItems(todos.Select(todo => new TodoItemViewModel(todo)));
+    }
+
+    private bool IsCurrentLoad(Guid boxId, int version)
+    {
+        return version == Volatile.Read(ref _loadVersion)
+            && BoxId == boxId;
+    }
+
+    private void ReplaceItems(IEnumerable<TodoItemViewModel> todos)
+    {
+        ActiveTodos.Clear();
+        CompletedTodos.Clear();
+        foreach (var todo in todos)
+        {
+            if (todo.IsCompleted)
+            {
+                CompletedTodos.Add(todo);
+            }
+            else
+            {
+                ActiveTodos.Add(todo);
+            }
+        }
+
+        OnPropertyChanged(nameof(RemainingCount));
+        OnPropertyChanged(nameof(CompletedCount));
+        OnPropertyChanged(nameof(TotalCount));
+        OnPropertyChanged(nameof(CompletionPercentage));
+        OnPropertyChanged(nameof(IsEmpty));
+        OnPropertyChanged(nameof(HasActiveTodos));
+        OnPropertyChanged(nameof(HasCompletedTodos));
+        NotifyCommandStateChanged();
+    }
+
+    private void NotifyCommandStateChanged()
+    {
+        AddTodoCommand.NotifyCanExecuteChanged();
+        ArchiveCompletedCommand.NotifyCanExecuteChanged();
+    }
+}

--- a/src/WitchDrawer.App/ViewModels/TodoBoxDetailViewModel.cs
+++ b/src/WitchDrawer.App/ViewModels/TodoBoxDetailViewModel.cs
@@ -2,14 +2,14 @@ using System.Collections.ObjectModel;
 using System.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using WitchDrawer.Core.Abstractions;
 using WitchDrawer.Core.Logging;
-using WitchDrawer.Core.Services;
 
 namespace WitchDrawer.App.ViewModels;
 
 public sealed class TodoBoxDetailViewModel : ObservableObject
 {
-    private readonly TodoService _todoService;
+    private readonly ITodoService _todoService;
     private readonly IAppLogger _logger;
     private CancellationTokenSource? _loadCts;
     private int _loadVersion;
@@ -19,7 +19,7 @@ public sealed class TodoBoxDetailViewModel : ObservableObject
     private bool _isBusy;
 
     public TodoBoxDetailViewModel(
-        TodoService todoService,
+        ITodoService todoService,
         IAppLogger logger)
     {
         _todoService = todoService;
@@ -176,7 +176,7 @@ public sealed class TodoBoxDetailViewModel : ObservableObject
         var normalizedTitle = NewTodoTitle.Trim();
         return BoxId is not null
             && !IsBusy
-            && normalizedTitle.Length is > 0 and <= TodoService.MaximumTitleLength;
+            && normalizedTitle.Length is > 0 and <= 200;
     }
 
     private async Task AddTodoAsync()

--- a/src/WitchDrawer.App/Views/DesktopBoxWindow.xaml
+++ b/src/WitchDrawer.App/Views/DesktopBoxWindow.xaml
@@ -181,7 +181,7 @@
                     <DataTrigger Binding="{Binding IsDragOver}" Value="True">
                         <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
                     </DataTrigger>
-                    <DataTrigger Binding="{Binding Type}" Value="Pixel">
+                    <DataTrigger Binding="{Binding IsPixelStyle}" Value="True">
                         <Setter Property="CornerRadius" Value="14" />
                         <Setter Property="TextElement.FontFamily" Value="Consolas, Courier New, 微软雅黑" />
                     </DataTrigger>
@@ -205,7 +205,7 @@
                         <Setter Property="Fill" Value="Transparent" />
                         <Setter Property="Visibility" Value="Collapsed" />
                         <Style.Triggers>
-                            <DataTrigger Binding="{Binding Type}" Value="Pixel">
+                            <DataTrigger Binding="{Binding IsPixelStyle}" Value="True">
                                 <Setter Property="Fill" Value="{StaticResource DotGridBrush}" />
                                 <Setter Property="Visibility" Value="Visible" />
                             </DataTrigger>
@@ -434,7 +434,7 @@
                                             <Style TargetType="Border">
                                                 <Setter Property="CornerRadius" Value="{Binding DataContext.LayoutSettings.ItemCornerRadius, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}" />
                                                 <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding DataContext.Type, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}" Value="Pixel">
+                                                    <DataTrigger Binding="{Binding DataContext.IsPixelStyle, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}" Value="True">
                                                         <Setter Property="CornerRadius" Value="6" />
                                                     </DataTrigger>
                                                 </Style.Triggers>
@@ -451,6 +451,7 @@
                                             <MultiDataTrigger.Conditions>
                                                 <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource Self}}" Value="True" />
                                                 <Condition Binding="{Binding DataContext.Type, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}" Value="Normal" />
+                                                <Condition Binding="{Binding DataContext.IsPixelStyle, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}" Value="False" />
                                             </MultiDataTrigger.Conditions>
                                             <Setter TargetName="Root" Property="Background" Value="{DynamicResource HoverBrush}" />
                                             <MultiDataTrigger.EnterActions>
@@ -500,7 +501,7 @@
                                         <MultiDataTrigger>
                                             <MultiDataTrigger.Conditions>
                                                 <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource Self}}" Value="True" />
-                                                <Condition Binding="{Binding DataContext.Type, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}" Value="Pixel" />
+                                                <Condition Binding="{Binding DataContext.IsPixelStyle, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}" Value="True" />
                                             </MultiDataTrigger.Conditions>
                                             <Setter TargetName="Root" Property="Background" Value="{DynamicResource HoverBrush}" />
                                         </MultiDataTrigger>
@@ -556,7 +557,7 @@
                             </Border>
                         </Grid>
                         <DataTemplate.Triggers>
-                            <DataTrigger Binding="{Binding DataContext.Type, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}" Value="Pixel">
+                            <DataTrigger Binding="{Binding DataContext.IsPixelStyle, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}" Value="True">
                                 <Setter TargetName="IconBorder" Property="CornerRadius" Value="4" />
                                 <Setter TargetName="IconImage" Property="RenderOptions.BitmapScalingMode" Value="NearestNeighbor" />
                             </DataTrigger>
@@ -915,7 +916,7 @@
                             <Setter Property="RadiusX" Value="{Binding LayoutSettings.ItemCornerRadius.TopLeft}" />
                             <Setter Property="RadiusY" Value="{Binding LayoutSettings.ItemCornerRadius.TopLeft}" />
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding Type}" Value="Pixel">
+                                <DataTrigger Binding="{Binding IsPixelStyle}" Value="True">
                                     <Setter Property="RadiusX" Value="6" />
                                     <Setter Property="RadiusY" Value="6" />
                                 </DataTrigger>
@@ -955,7 +956,7 @@
                                 <Setter Property="RadiusX" Value="16" />
                                 <Setter Property="RadiusY" Value="16" />
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Type}" Value="Pixel">
+                                    <DataTrigger Binding="{Binding IsPixelStyle}" Value="True">
                                         <Setter Property="RadiusX" Value="6" />
                                         <Setter Property="RadiusY" Value="6" />
                                     </DataTrigger>

--- a/src/WitchDrawer.App/Views/DesktopBoxWindow.xaml.cs
+++ b/src/WitchDrawer.App/Views/DesktopBoxWindow.xaml.cs
@@ -28,6 +28,7 @@ public partial class DesktopBoxWindow : Window
     private bool _isMappingViewTransitioning;
     private bool _restoreAfterMinimizeQueued;
     private bool _desktopIsForeground;
+    private bool _isPositionLocked;
     private HwndSource? _source;
     private DesktopToolWindow? _nativeWindow;
 
@@ -92,6 +93,11 @@ public partial class DesktopBoxWindow : Window
     {
         SendToBottom();
         Dispatcher.BeginInvoke(new Action(SendToBottom), DispatcherPriority.ApplicationIdle);
+    }
+
+    public void SetPositionLocked(bool isPositionLocked)
+    {
+        _isPositionLocked = isPositionLocked;
     }
 
     public nint NativeHandle => _nativeWindow?.Handle ?? nint.Zero;
@@ -591,6 +597,11 @@ public partial class DesktopBoxWindow : Window
         }
 
         ClearItemSelection();
+
+        if (_isPositionLocked)
+        {
+            return;
+        }
 
         if (e.ButtonState == MouseButtonState.Pressed)
         {

--- a/src/WitchDrawer.App/Views/TodoBoxDetailView.xaml
+++ b/src/WitchDrawer.App/Views/TodoBoxDetailView.xaml
@@ -1,0 +1,467 @@
+<UserControl x:Class="WitchDrawer.App.Views.TodoBoxDetailView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             MinHeight="300"
+             UseLayoutRounding="True"
+             SnapsToDevicePixels="True">
+    <UserControl.Resources>
+        <Style x:Key="TodoSummaryCardStyle" TargetType="{x:Type Border}">
+            <Setter Property="Background" Value="{DynamicResource PanelBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushSoft}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="12" />
+            <Setter Property="Padding" Value="13,9" />
+        </Style>
+
+        <Style x:Key="TodoRowContainerStyle" TargetType="{x:Type ListBoxItem}">
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="Margin" Value="0,0,0,4" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                        <Border x:Name="RowSurface"
+                                MinHeight="45"
+                                Padding="10,7"
+                                Background="Transparent"
+                                BorderBrush="Transparent"
+                                BorderThickness="1"
+                                CornerRadius="10">
+                            <ContentPresenter />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="RowSurface"
+                                        Property="Background"
+                                        Value="{DynamicResource HoverBrush}" />
+                                <Setter TargetName="RowSurface"
+                                        Property="BorderBrush"
+                                        Value="{DynamicResource BorderBrushSoft}" />
+                            </Trigger>
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter TargetName="RowSurface"
+                                        Property="Background"
+                                        Value="{DynamicResource AccentSoftBrush}" />
+                                <Setter TargetName="RowSurface"
+                                        Property="BorderBrush"
+                                        Value="{DynamicResource AccentBrush}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="TodoCompletionButtonStyle" TargetType="{x:Type Button}">
+            <Setter Property="Width" Value="25" />
+            <Setter Property="Height" Value="25" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type Button}">
+                        <Grid>
+                            <Ellipse x:Name="CompletionRing"
+                                     Fill="Transparent"
+                                     Stroke="{DynamicResource BorderBrushSoft}"
+                                     StrokeThickness="1.5" />
+                            <Path x:Name="CompletionCheck"
+                                  Data="M 4,9 L 8,13 L 16,5"
+                                  Width="12"
+                                  Height="9"
+                                  Stroke="White"
+                                  StrokeThickness="2"
+                                  StrokeStartLineCap="Round"
+                                  StrokeEndLineCap="Round"
+                                  StrokeLineJoin="Round"
+                                  Stretch="Uniform"
+                                  Visibility="Collapsed" />
+                        </Grid>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="CompletionRing"
+                                        Property="Stroke"
+                                        Value="{DynamicResource AccentBrush}" />
+                                <Setter TargetName="CompletionRing"
+                                        Property="Fill"
+                                        Value="{DynamicResource AccentSoftBrush}" />
+                            </Trigger>
+                            <DataTrigger Binding="{Binding IsCompleted}" Value="True">
+                                <Setter TargetName="CompletionRing"
+                                        Property="Fill"
+                                        Value="{DynamicResource AccentBrush}" />
+                                <Setter TargetName="CompletionRing"
+                                        Property="Stroke"
+                                        Value="{DynamicResource AccentBrush}" />
+                                <Setter TargetName="CompletionCheck"
+                                        Property="Visibility"
+                                        Value="Visible" />
+                            </DataTrigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <DataTemplate x:Key="TodoDetailItemTemplate">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <Button Command="{Binding DataContext.ToggleTodoCommand, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
+                        CommandParameter="{Binding}"
+                        Style="{StaticResource TodoCompletionButtonStyle}"
+                        Margin="0,0,10,0"
+                        VerticalAlignment="Center"
+                        ToolTip="切换完成状态" />
+
+                <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                    <TextBlock Text="{Binding Title}"
+                               Foreground="{DynamicResource TextPrimaryBrush}"
+                               FontSize="12.5"
+                               FontWeight="SemiBold"
+                               TextWrapping="Wrap">
+                        <TextBlock.Style>
+                            <Style TargetType="{x:Type TextBlock}">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsCompleted}" Value="True">
+                                        <Setter Property="TextDecorations" Value="Strikethrough" />
+                                        <Setter Property="Opacity" Value="0.5" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    <TextBlock Text="{Binding TimeLabel}"
+                               Margin="0,2,0,0"
+                               Foreground="{DynamicResource TextMutedBrush}"
+                               FontSize="9.5" />
+                </StackPanel>
+
+                <Button Grid.Column="2"
+                        Command="{Binding DataContext.DeleteTodoCommand, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
+                        CommandParameter="{Binding}"
+                        Width="28"
+                        Height="28"
+                        Margin="8,0,0,0"
+                        Padding="0"
+                        Style="{StaticResource GhostButtonStyle}"
+                        Foreground="{DynamicResource TextMutedBrush}"
+                        ToolTip="删除这项待办">
+                    <TextBlock Text="&#xE74D;"
+                               FontFamily="Segoe Fluent Icons"
+                               FontSize="12"
+                               Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}" />
+                </Button>
+            </Grid>
+        </DataTemplate>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Grid Grid.Row="0" Margin="0,0,0,9">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1.08*" />
+                <ColumnDefinition Width="1.08*" />
+                <ColumnDefinition Width="1.5*" />
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0"
+                    Margin="0,0,7,0"
+                    Style="{StaticResource TodoSummaryCardStyle}">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Border Width="30"
+                            Height="30"
+                            CornerRadius="9"
+                            Background="{DynamicResource AccentSoftBrush}">
+                        <TextBlock Text="&#xE8FD;"
+                                   FontFamily="Segoe Fluent Icons"
+                                   FontSize="14"
+                                   Foreground="{DynamicResource AccentBrush}"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center" />
+                    </Border>
+                    <StackPanel Grid.Column="1" Margin="9,0,0,0" VerticalAlignment="Center">
+                        <TextBlock Text="待完成"
+                                   Foreground="{DynamicResource TextMutedBrush}"
+                                   FontSize="10" />
+                        <TextBlock Text="{Binding RemainingCount}"
+                                   Foreground="{DynamicResource TextPrimaryBrush}"
+                                   FontSize="18"
+                                   FontWeight="SemiBold" />
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <Border Grid.Column="1"
+                    Margin="0,0,7,0"
+                    Style="{StaticResource TodoSummaryCardStyle}">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Border Width="30"
+                            Height="30"
+                            CornerRadius="9"
+                            Background="{DynamicResource GlassInnerBrush}">
+                        <TextBlock Text="&#xE73E;"
+                                   FontFamily="Segoe Fluent Icons"
+                                   FontSize="14"
+                                   Foreground="{DynamicResource TextMutedBrush}"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center" />
+                    </Border>
+                    <StackPanel Grid.Column="1" Margin="9,0,0,0" VerticalAlignment="Center">
+                        <TextBlock Text="已完成"
+                                   Foreground="{DynamicResource TextMutedBrush}"
+                                   FontSize="10" />
+                        <TextBlock Text="{Binding CompletedCount}"
+                                   Foreground="{DynamicResource TextPrimaryBrush}"
+                                   FontSize="18"
+                                   FontWeight="SemiBold" />
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <Border Grid.Column="2"
+                    Style="{StaticResource TodoSummaryCardStyle}">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel VerticalAlignment="Center">
+                        <TextBlock Text="今日进度"
+                                   Foreground="{DynamicResource TextMutedBrush}"
+                                   FontSize="10" />
+                        <ProgressBar Height="5"
+                                     Margin="0,7,12,0"
+                                     Minimum="0"
+                                     Maximum="100"
+                                     Value="{Binding CompletionPercentage, Mode=OneWay}"
+                                     Foreground="{DynamicResource AccentBrush}"
+                                     Background="{DynamicResource PanelAltBrush}"
+                                     BorderThickness="0" />
+                    </StackPanel>
+                    <TextBlock Grid.Column="1"
+                               Text="{Binding CompletionPercentage, StringFormat={}{0}%}"
+                               Foreground="{DynamicResource AccentBrush}"
+                               FontSize="18"
+                               FontWeight="SemiBold"
+                               VerticalAlignment="Center" />
+                </Grid>
+            </Border>
+        </Grid>
+
+        <Border Grid.Row="1"
+                Margin="0,0,0,9"
+                Padding="8"
+                Background="{DynamicResource PanelBrush}"
+                BorderBrush="{DynamicResource BorderBrushSoft}"
+                BorderThickness="1"
+                CornerRadius="12">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <Border Width="34"
+                        Height="34"
+                        CornerRadius="9"
+                        Background="{DynamicResource AccentSoftBrush}">
+                    <TextBlock Text="+"
+                               Foreground="{DynamicResource AccentBrush}"
+                               FontSize="20"
+                               FontWeight="Medium"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center" />
+                </Border>
+
+                <Grid Grid.Column="1" Margin="9,0">
+                    <TextBox Text="{Binding NewTodoTitle, UpdateSourceTrigger=PropertyChanged}"
+                             MaxLength="200"
+                             Height="34"
+                             Padding="9,0"
+                             VerticalContentAlignment="Center"
+                             Foreground="{DynamicResource TextPrimaryBrush}"
+                             Background="{DynamicResource PanelAltBrush}"
+                             BorderBrush="{DynamicResource BorderBrushSoft}"
+                             BorderThickness="1"
+                             FontSize="12"
+                             ToolTip="输入任务，按 Enter 添加" />
+                    <TextBlock Text="写下一件要做的事…"
+                               Margin="10,0,0,0"
+                               Foreground="{DynamicResource TextMutedBrush}"
+                               FontSize="11.5"
+                               VerticalAlignment="Center"
+                               IsHitTestVisible="False">
+                        <TextBlock.Style>
+                            <Style TargetType="{x:Type TextBlock}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding NewTodoTitle}" Value="">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Grid>
+
+                <Button Grid.Column="2"
+                        Content="添加任务"
+                        Command="{Binding AddTodoCommand}"
+                        IsDefault="True"
+                        Height="34"
+                        Padding="16,0"
+                        Style="{StaticResource PrimaryButtonStyle}" />
+            </Grid>
+        </Border>
+
+        <Border Grid.Row="2"
+                Padding="12"
+                Background="{DynamicResource PanelBrush}"
+                BorderBrush="{DynamicResource BorderBrushSoft}"
+                BorderThickness="1"
+                CornerRadius="12">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <Grid Grid.Row="0" Margin="2,0,2,9">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <Border Width="16"
+                                Height="3"
+                                Margin="0,0,7,0"
+                                CornerRadius="2"
+                                Background="{DynamicResource AccentBrush}" />
+                        <TextBlock Text="今日清单"
+                                   Foreground="{DynamicResource TextPrimaryBrush}"
+                                   FontSize="13"
+                                   FontWeight="SemiBold" />
+                        <TextBlock Text="{Binding StatusText, StringFormat=  ·  {0}}"
+                                   Foreground="{DynamicResource TextMutedBrush}"
+                                   FontSize="10.5"
+                                   VerticalAlignment="Center" />
+                    </StackPanel>
+                    <Border Grid.Column="1"
+                            Padding="8,3"
+                            Background="{DynamicResource AccentSoftBrush}"
+                            CornerRadius="8">
+                        <TextBlock Text="{Binding TotalCount, StringFormat={}{0} 项}"
+                                   Foreground="{DynamicResource AccentBrush}"
+                                   FontSize="10.5"
+                                   FontWeight="SemiBold" />
+                    </Border>
+                </Grid>
+
+                <Grid Grid.Row="1">
+                    <StackPanel HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Visibility="{Binding HasActiveTodos, Converter={StaticResource InverseBooleanToVisibilityConverter}}">
+                        <Border Width="46"
+                                Height="46"
+                                CornerRadius="14"
+                                Background="{DynamicResource AccentSoftBrush}">
+                            <TextBlock Text="&#xE73E;"
+                                       FontFamily="Segoe Fluent Icons"
+                                       FontSize="20"
+                                       Foreground="{DynamicResource AccentBrush}"
+                                       HorizontalAlignment="Center"
+                                       VerticalAlignment="Center" />
+                        </Border>
+                        <TextBlock Text="今天没有待完成事项"
+                                   Margin="0,9,0,0"
+                                   Foreground="{DynamicResource TextPrimaryBrush}"
+                                   FontSize="13"
+                                   FontWeight="SemiBold" />
+                        <TextBlock Text="在上方写下一件要做的小事"
+                                   Margin="0,3,0,0"
+                                   Foreground="{DynamicResource TextMutedBrush}"
+                                   FontSize="10.5" />
+                    </StackPanel>
+
+                    <ListBox ItemsSource="{Binding ActiveTodos}"
+                             ItemTemplate="{StaticResource TodoDetailItemTemplate}"
+                             ItemContainerStyle="{StaticResource TodoRowContainerStyle}"
+                             ScrollViewer.CanContentScroll="True"
+                             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto"
+                             VirtualizingPanel.IsVirtualizing="True"
+                             VirtualizingPanel.VirtualizationMode="Recycling"
+                             Visibility="{Binding HasActiveTodos, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                </Grid>
+
+                <Grid Grid.Row="2"
+                      Margin="2,8,2,5"
+                      Visibility="{Binding HasCompletedTodos, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <TextBlock Text="已完成"
+                                   Foreground="{DynamicResource TextMutedBrush}"
+                                   FontSize="10.5"
+                                   FontWeight="SemiBold" />
+                        <Border Margin="6,0,0,0"
+                                Padding="6,2"
+                                Background="{DynamicResource PanelAltBrush}"
+                                CornerRadius="6">
+                            <TextBlock Text="{Binding CompletedCount}"
+                                       Foreground="{DynamicResource TextMutedBrush}"
+                                       FontSize="9.5"
+                                       FontWeight="SemiBold" />
+                        </Border>
+                    </StackPanel>
+                    <Button Grid.Column="1"
+                            Content="归档已完成"
+                            Command="{Binding ArchiveCompletedCommand}"
+                            Height="26"
+                            Padding="10,0"
+                            Style="{StaticResource GhostButtonStyle}"
+                            Foreground="{DynamicResource TextMutedBrush}"
+                            FontSize="10.5" />
+                </Grid>
+
+                <ListBox Grid.Row="3"
+                         MaxHeight="94"
+                         ItemsSource="{Binding CompletedTodos}"
+                         ItemTemplate="{StaticResource TodoDetailItemTemplate}"
+                         ItemContainerStyle="{StaticResource TodoRowContainerStyle}"
+                         ScrollViewer.CanContentScroll="True"
+                         ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto"
+                         VirtualizingPanel.IsVirtualizing="True"
+                         VirtualizingPanel.VirtualizationMode="Recycling"
+                         Visibility="{Binding HasCompletedTodos, Converter={StaticResource BooleanToVisibilityConverter}}" />
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/src/WitchDrawer.App/Views/TodoBoxDetailView.xaml.cs
+++ b/src/WitchDrawer.App/Views/TodoBoxDetailView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace WitchDrawer.App.Views;
+
+public partial class TodoBoxDetailView : UserControl
+{
+    public TodoBoxDetailView()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/WitchDrawer.App.Tests/BoxPositionLockStateStoreTests.cs
+++ b/tests/WitchDrawer.App.Tests/BoxPositionLockStateStoreTests.cs
@@ -1,0 +1,116 @@
+using System.IO;
+using WitchDrawer.App.Infrastructure;
+using WitchDrawer.Core;
+using WitchDrawer.Core.Logging;
+using WitchDrawer.Core.Services;
+using WitchDrawer.Core.Storage;
+
+namespace WitchDrawer.App.Tests;
+
+public sealed class BoxPositionLockStateStoreTests
+{
+    [Fact]
+    public async Task LoadAsync_UsesUnlockedStateWithoutSavedPreference()
+    {
+        await using var workspace = await TestWorkspace.CreateAsync();
+
+        var isPositionLocked = await workspace.Store.LoadAsync(Guid.NewGuid());
+
+        Assert.False(isPositionLocked);
+    }
+
+    [Fact]
+    public async Task SaveAsync_PersistsPositionLockState()
+    {
+        await using var workspace = await TestWorkspace.CreateAsync();
+        var boxId = Guid.NewGuid();
+
+        await workspace.Store.SaveAsync(boxId, isPositionLocked: true);
+
+        var reloadedStore = new BoxPositionLockStateStore(workspace.DrawerService, workspace.Logger);
+        Assert.True(await reloadedStore.LoadAsync(boxId));
+    }
+
+    [Fact]
+    public async Task LoadAsync_InvalidSavedValueFallsBackWithoutThrowing()
+    {
+        await using var workspace = await TestWorkspace.CreateAsync();
+        var boxId = Guid.NewGuid();
+        await workspace.DrawerService.SetSettingAsync(
+            BoxPositionLockStateStore.GetSettingKey(boxId),
+            "not-a-boolean");
+
+        var isPositionLocked = await workspace.Store.LoadAsync(boxId);
+
+        Assert.False(isPositionLocked);
+        Assert.Single(workspace.Logger.Errors);
+    }
+
+    private sealed class TestWorkspace : IAsyncDisposable
+    {
+        private TestWorkspace(
+            string root,
+            DrawerService drawerService,
+            RecordingLogger logger,
+            BoxPositionLockStateStore store)
+        {
+            Root = root;
+            DrawerService = drawerService;
+            Logger = logger;
+            Store = store;
+        }
+
+        public string Root { get; }
+
+        public DrawerService DrawerService { get; }
+
+        public RecordingLogger Logger { get; }
+
+        public BoxPositionLockStateStore Store { get; }
+
+        public static async Task<TestWorkspace> CreateAsync()
+        {
+            var root = Path.Combine(
+                Path.GetTempPath(),
+                "WitchDrawerTests",
+                Guid.NewGuid().ToString("N"));
+            var paths = new AppPaths(root);
+            var repository = new DrawerRepository(paths.DatabasePath);
+            var drawerService = new DrawerService(paths, repository);
+            await drawerService.InitializeAsync();
+            var logger = new RecordingLogger();
+            return new TestWorkspace(
+                root,
+                drawerService,
+                logger,
+                new BoxPositionLockStateStore(drawerService, logger));
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            if (Directory.Exists(Root))
+            {
+                Directory.Delete(Root, recursive: true);
+            }
+
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingLogger : IAppLogger
+    {
+        public List<string> Information { get; } = [];
+
+        public List<(Exception Exception, string Message)> Errors { get; } = [];
+
+        public void Info(string message)
+        {
+            Information.Add(message);
+        }
+
+        public void Error(Exception exception, string message)
+        {
+            Errors.Add((exception, message));
+        }
+    }
+}

--- a/tests/WitchDrawer.App.Tests/BoxPositionLockStateStoreTests.cs
+++ b/tests/WitchDrawer.App.Tests/BoxPositionLockStateStoreTests.cs
@@ -1,9 +1,9 @@
 using System.IO;
 using WitchDrawer.App.Infrastructure;
 using WitchDrawer.Core;
+using WitchDrawer.Core.Abstractions;
 using WitchDrawer.Core.Logging;
 using WitchDrawer.Core.Services;
-using WitchDrawer.Core.Storage;
 
 namespace WitchDrawer.App.Tests;
 
@@ -50,7 +50,7 @@ public sealed class BoxPositionLockStateStoreTests
     {
         private TestWorkspace(
             string root,
-            DrawerService drawerService,
+            IDrawerService drawerService,
             RecordingLogger logger,
             BoxPositionLockStateStore store)
         {
@@ -62,7 +62,7 @@ public sealed class BoxPositionLockStateStoreTests
 
         public string Root { get; }
 
-        public DrawerService DrawerService { get; }
+        public IDrawerService DrawerService { get; }
 
         public RecordingLogger Logger { get; }
 
@@ -75,8 +75,7 @@ public sealed class BoxPositionLockStateStoreTests
                 "WitchDrawerTests",
                 Guid.NewGuid().ToString("N"));
             var paths = new AppPaths(root);
-            var repository = new DrawerRepository(paths.DatabasePath);
-            var drawerService = new DrawerService(paths, repository);
+            var drawerService = new RustDrawerService(paths.RootDirectory);
             await drawerService.InitializeAsync();
             var logger = new RecordingLogger();
             return new TestWorkspace(
@@ -88,6 +87,11 @@ public sealed class BoxPositionLockStateStoreTests
 
         public ValueTask DisposeAsync()
         {
+            if (DrawerService is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+
             if (Directory.Exists(Root))
             {
                 Directory.Delete(Root, recursive: true);

--- a/tests/WitchDrawer.App.Tests/BoxVisualStyleStoreTests.cs
+++ b/tests/WitchDrawer.App.Tests/BoxVisualStyleStoreTests.cs
@@ -1,0 +1,161 @@
+using System.IO;
+using WitchDrawer.App.Infrastructure;
+using WitchDrawer.App.ViewModels;
+using WitchDrawer.Core;
+using WitchDrawer.Core.Logging;
+using WitchDrawer.Core.Models;
+using WitchDrawer.Core.Services;
+using WitchDrawer.Core.Storage;
+
+namespace WitchDrawer.App.Tests;
+
+public sealed class BoxVisualStyleStoreTests
+{
+    [Fact]
+    public async Task LoadAsync_UsesModernStyleForNormalBoxWithoutSavedPreference()
+    {
+        await using var workspace = await TestWorkspace.CreateAsync();
+        var box = CreateBox(BoxType.Normal);
+
+        var style = await workspace.Store.LoadAsync(box);
+
+        Assert.Equal(BoxVisualStyle.Modern, style);
+    }
+
+    [Fact]
+    public async Task LoadAsync_UsesPixelStyleForLegacyPixelBoxWithoutSavedPreference()
+    {
+        await using var workspace = await TestWorkspace.CreateAsync();
+        var box = CreateBox(BoxType.Pixel);
+
+        var style = await workspace.Store.LoadAsync(box);
+
+        Assert.Equal(BoxVisualStyle.Pixel, style);
+    }
+
+    [Fact]
+    public async Task SaveAsync_PersistsPixelStyleForNormalBox()
+    {
+        await using var workspace = await TestWorkspace.CreateAsync();
+        var box = CreateBox(BoxType.Normal);
+
+        await workspace.Store.SaveAsync(box.Id, BoxVisualStyle.Pixel);
+
+        var reloadedStore = new BoxVisualStyleStore(workspace.DrawerService, workspace.Logger);
+        Assert.Equal(BoxVisualStyle.Pixel, await reloadedStore.LoadAsync(box));
+    }
+
+    [Fact]
+    public async Task SavedModernStyle_OverridesLegacyPixelFallback()
+    {
+        await using var workspace = await TestWorkspace.CreateAsync();
+        var box = CreateBox(BoxType.Pixel);
+
+        await workspace.Store.SaveAsync(box.Id, BoxVisualStyle.Modern);
+
+        Assert.Equal(BoxVisualStyle.Modern, await workspace.Store.LoadAsync(box));
+    }
+
+    [Fact]
+    public async Task LoadAsync_InvalidSavedValueFallsBackWithoutThrowing()
+    {
+        await using var workspace = await TestWorkspace.CreateAsync();
+        var box = CreateBox(BoxType.Normal);
+        await workspace.DrawerService.SetSettingAsync(
+            BoxVisualStyleStore.GetSettingKey(box.Id),
+            "unsupported-style");
+
+        var style = await workspace.Store.LoadAsync(box);
+
+        Assert.Equal(BoxVisualStyle.Modern, style);
+        Assert.Single(workspace.Logger.Errors);
+    }
+
+    [Fact]
+    public async Task LoadAsync_IgnoresSavedStyleForMappingBox()
+    {
+        await using var workspace = await TestWorkspace.CreateAsync();
+        var box = CreateBox(BoxType.Mapping);
+        await workspace.DrawerService.SetSettingAsync(
+            BoxVisualStyleStore.GetSettingKey(box.Id),
+            BoxVisualStyle.Pixel.ToString());
+
+        var style = await workspace.Store.LoadAsync(box);
+
+        Assert.Equal(BoxVisualStyle.Modern, style);
+    }
+
+    private static Box CreateBox(BoxType type)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new Box(Guid.NewGuid(), "Test", type, null, 0, now, now);
+    }
+
+    private sealed class TestWorkspace : IAsyncDisposable
+    {
+        private TestWorkspace(
+            string root,
+            DrawerService drawerService,
+            RecordingLogger logger,
+            BoxVisualStyleStore store)
+        {
+            Root = root;
+            DrawerService = drawerService;
+            Logger = logger;
+            Store = store;
+        }
+
+        public string Root { get; }
+
+        public DrawerService DrawerService { get; }
+
+        public RecordingLogger Logger { get; }
+
+        public BoxVisualStyleStore Store { get; }
+
+        public static async Task<TestWorkspace> CreateAsync()
+        {
+            var root = Path.Combine(
+                Path.GetTempPath(),
+                "WitchDrawerTests",
+                Guid.NewGuid().ToString("N"));
+            var paths = new AppPaths(root);
+            var repository = new DrawerRepository(paths.DatabasePath);
+            var drawerService = new DrawerService(paths, repository);
+            await drawerService.InitializeAsync();
+            var logger = new RecordingLogger();
+            return new TestWorkspace(
+                root,
+                drawerService,
+                logger,
+                new BoxVisualStyleStore(drawerService, logger));
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            if (Directory.Exists(Root))
+            {
+                Directory.Delete(Root, recursive: true);
+            }
+
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingLogger : IAppLogger
+    {
+        public List<string> Information { get; } = [];
+
+        public List<(Exception Exception, string Message)> Errors { get; } = [];
+
+        public void Info(string message)
+        {
+            Information.Add(message);
+        }
+
+        public void Error(Exception exception, string message)
+        {
+            Errors.Add((exception, message));
+        }
+    }
+}

--- a/tests/WitchDrawer.App.Tests/BoxVisualStyleStoreTests.cs
+++ b/tests/WitchDrawer.App.Tests/BoxVisualStyleStoreTests.cs
@@ -2,10 +2,10 @@ using System.IO;
 using WitchDrawer.App.Infrastructure;
 using WitchDrawer.App.ViewModels;
 using WitchDrawer.Core;
+using WitchDrawer.Core.Abstractions;
 using WitchDrawer.Core.Logging;
 using WitchDrawer.Core.Models;
 using WitchDrawer.Core.Services;
-using WitchDrawer.Core.Storage;
 
 namespace WitchDrawer.App.Tests;
 
@@ -95,7 +95,7 @@ public sealed class BoxVisualStyleStoreTests
     {
         private TestWorkspace(
             string root,
-            DrawerService drawerService,
+            IDrawerService drawerService,
             RecordingLogger logger,
             BoxVisualStyleStore store)
         {
@@ -107,7 +107,7 @@ public sealed class BoxVisualStyleStoreTests
 
         public string Root { get; }
 
-        public DrawerService DrawerService { get; }
+        public IDrawerService DrawerService { get; }
 
         public RecordingLogger Logger { get; }
 
@@ -120,8 +120,7 @@ public sealed class BoxVisualStyleStoreTests
                 "WitchDrawerTests",
                 Guid.NewGuid().ToString("N"));
             var paths = new AppPaths(root);
-            var repository = new DrawerRepository(paths.DatabasePath);
-            var drawerService = new DrawerService(paths, repository);
+            var drawerService = new RustDrawerService(paths.RootDirectory);
             await drawerService.InitializeAsync();
             var logger = new RecordingLogger();
             return new TestWorkspace(
@@ -133,6 +132,11 @@ public sealed class BoxVisualStyleStoreTests
 
         public ValueTask DisposeAsync()
         {
+            if (DrawerService is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+
             if (Directory.Exists(Root))
             {
                 Directory.Delete(Root, recursive: true);

--- a/tests/WitchDrawer.App.Tests/StyledNormalBoxCreationTests.cs
+++ b/tests/WitchDrawer.App.Tests/StyledNormalBoxCreationTests.cs
@@ -1,0 +1,88 @@
+using System.IO;
+using WitchDrawer.App.Infrastructure;
+using WitchDrawer.App.ViewModels;
+using WitchDrawer.Core;
+using WitchDrawer.Core.Abstractions;
+using WitchDrawer.Core.Logging;
+using WitchDrawer.Core.Models;
+using WitchDrawer.Core.Services;
+using WitchDrawer.Core.Storage;
+
+namespace WitchDrawer.App.Tests;
+
+public sealed class StyledNormalBoxCreationTests
+{
+    [Fact]
+    public async Task PixelStyleCreation_PreservesNormalBoxFileBehavior()
+    {
+        var root = Path.Combine(
+            Path.GetTempPath(),
+            "WitchDrawerTests",
+            Guid.NewGuid().ToString("N"));
+        try
+        {
+            var paths = new AppPaths(root);
+            var repository = new DrawerRepository(paths.DatabasePath);
+            var drawerService = new DrawerService(paths, repository);
+            await drawerService.InitializeAsync();
+            var logger = new RecordingLogger();
+            var launcher = new NoOpFileLauncher();
+            var visualStyleStore = new BoxVisualStyleStore(drawerService, logger);
+            var quickPanel = new QuickPanelViewModel(
+                drawerService,
+                launcher,
+                logger,
+                visualStyleStore);
+            var viewModel = new MainViewModel(
+                drawerService,
+                new TodoService(repository),
+                launcher,
+                logger,
+                quickPanel,
+                new UpdateService(logger),
+                visualStyleStore,
+                new BoxPositionLockStateStore(drawerService, logger));
+            var existingIds = (await drawerService.GetBoxesAsync())
+                .Select(box => box.Id)
+                .ToHashSet();
+
+            await viewModel.CreatePixelBoxCommand.ExecuteAsync(null);
+
+            var createdBox = Assert.Single(
+                await drawerService.GetBoxesAsync(),
+                box => !existingIds.Contains(box.Id));
+            Assert.Equal(BoxType.Normal, createdBox.Type);
+            Assert.Equal(
+                BoxVisualStyle.Pixel,
+                await visualStyleStore.LoadAsync(createdBox));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    private sealed class NoOpFileLauncher : IFileLauncher
+    {
+        public Task OpenAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingLogger : IAppLogger
+    {
+        public void Info(string message)
+        {
+        }
+
+        public void Error(Exception exception, string message)
+        {
+        }
+    }
+}

--- a/tests/WitchDrawer.App.Tests/StyledNormalBoxCreationTests.cs
+++ b/tests/WitchDrawer.App.Tests/StyledNormalBoxCreationTests.cs
@@ -6,7 +6,6 @@ using WitchDrawer.Core.Abstractions;
 using WitchDrawer.Core.Logging;
 using WitchDrawer.Core.Models;
 using WitchDrawer.Core.Services;
-using WitchDrawer.Core.Storage;
 
 namespace WitchDrawer.App.Tests;
 
@@ -22,8 +21,7 @@ public sealed class StyledNormalBoxCreationTests
         try
         {
             var paths = new AppPaths(root);
-            var repository = new DrawerRepository(paths.DatabasePath);
-            var drawerService = new DrawerService(paths, repository);
+            using var drawerService = new RustDrawerService(paths.RootDirectory);
             await drawerService.InitializeAsync();
             var logger = new RecordingLogger();
             var launcher = new NoOpFileLauncher();
@@ -35,11 +33,11 @@ public sealed class StyledNormalBoxCreationTests
                 visualStyleStore);
             var viewModel = new MainViewModel(
                 drawerService,
-                new TodoService(repository),
+                new RustTodoService(drawerService),
                 launcher,
                 logger,
                 quickPanel,
-                new UpdateService(logger),
+                new RustUpdateService(drawerService, logger),
                 visualStyleStore,
                 new BoxPositionLockStateStore(drawerService, logger));
             var existingIds = (await drawerService.GetBoxesAsync())

--- a/tests/WitchDrawer.App.Tests/TodoBoxDetailViewModelTests.cs
+++ b/tests/WitchDrawer.App.Tests/TodoBoxDetailViewModelTests.cs
@@ -1,0 +1,228 @@
+using System.IO;
+using WitchDrawer.App.Infrastructure;
+using WitchDrawer.App.ViewModels;
+using WitchDrawer.Core;
+using WitchDrawer.Core.Abstractions;
+using WitchDrawer.Core.Logging;
+using WitchDrawer.Core.Models;
+using WitchDrawer.Core.Services;
+using WitchDrawer.Core.Storage;
+
+namespace WitchDrawer.App.Tests;
+
+public sealed class TodoBoxDetailViewModelTests
+{
+    [Fact]
+    public async Task LoadAsync_SeparatesActiveAndCompletedTodos()
+    {
+        using var workspace = await TodoWorkspace.CreateAsync();
+        var active = await workspace.TodoService.AddTodoAsync(
+            workspace.TodoBox.Id,
+            "整理桌面");
+        var completed = await workspace.TodoService.AddTodoAsync(
+            workspace.TodoBox.Id,
+            "清空下载目录");
+        await workspace.TodoService.SetCompletedAsync(completed.Id, isCompleted: true);
+        var viewModel = new TodoBoxDetailViewModel(
+            workspace.TodoService,
+            new RecordingLogger());
+
+        await viewModel.LoadAsync(workspace.TodoBox.Id);
+
+        Assert.Equal(workspace.TodoBox.Id, viewModel.BoxId);
+        Assert.Equal(active.Id, Assert.Single(viewModel.ActiveTodos).Id);
+        Assert.Equal(completed.Id, Assert.Single(viewModel.CompletedTodos).Id);
+        Assert.Equal(1, viewModel.RemainingCount);
+        Assert.Equal(1, viewModel.CompletedCount);
+        Assert.Equal(2, viewModel.TotalCount);
+        Assert.Equal(50, viewModel.CompletionPercentage);
+    }
+
+    [Fact]
+    public async Task Commands_AddCompleteAndArchiveWithinSelectedTodoBox()
+    {
+        using var workspace = await TodoWorkspace.CreateAsync();
+        var otherBox = await workspace.DrawerService.CreateBoxAsync(
+            "其他待办",
+            BoxType.Todo);
+        await workspace.TodoService.AddTodoAsync(otherBox.Id, "不应被改变");
+        var viewModel = new TodoBoxDetailViewModel(
+            workspace.TodoService,
+            new RecordingLogger());
+        var changeCount = 0;
+        viewModel.ItemsChanged += (_, _) => changeCount++;
+        await viewModel.LoadAsync(workspace.TodoBox.Id);
+
+        viewModel.NewTodoTitle = "  写周报  ";
+        await viewModel.AddTodoCommand.ExecuteAsync(null);
+        var added = Assert.Single(viewModel.ActiveTodos);
+        Assert.Equal("写周报", added.Title);
+
+        await viewModel.ToggleTodoCommand.ExecuteAsync(added);
+        var completed = Assert.Single(viewModel.CompletedTodos);
+        Assert.Equal(added.Id, completed.Id);
+
+        await viewModel.ArchiveCompletedCommand.ExecuteAsync(null);
+
+        Assert.Empty(viewModel.ActiveTodos);
+        Assert.Empty(viewModel.CompletedTodos);
+        Assert.Equal(3, changeCount);
+        Assert.Equal(
+            added.Id,
+            Assert.Single(
+                await workspace.TodoService.GetArchivedTodosAsync(
+                    workspace.TodoBox.Id)).Id);
+        Assert.Single(await workspace.TodoService.GetTodosAsync(otherBox.Id));
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithNoBox_ClearsStateAndDisablesMutations()
+    {
+        using var workspace = await TodoWorkspace.CreateAsync();
+        await workspace.TodoService.AddTodoAsync(
+            workspace.TodoBox.Id,
+            "临时事项");
+        var viewModel = new TodoBoxDetailViewModel(
+            workspace.TodoService,
+            new RecordingLogger());
+        await viewModel.LoadAsync(workspace.TodoBox.Id);
+
+        await viewModel.LoadAsync(null);
+
+        Assert.Null(viewModel.BoxId);
+        Assert.Empty(viewModel.ActiveTodos);
+        Assert.Empty(viewModel.CompletedTodos);
+        Assert.False(viewModel.AddTodoCommand.CanExecute(null));
+        Assert.False(viewModel.ArchiveCompletedCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task MainViewModel_SelectingTodoBoxRoutesToTodoDetail()
+    {
+        using var workspace = await TodoWorkspace.CreateAsync();
+        await workspace.TodoService.AddTodoAsync(
+            workspace.TodoBox.Id,
+            "主面板任务");
+        var logger = new RecordingLogger();
+        var launcher = new NoOpFileLauncher();
+        var visualStyleStore = new BoxVisualStyleStore(
+            workspace.DrawerService,
+            logger);
+        var quickPanel = new QuickPanelViewModel(
+            workspace.DrawerService,
+            launcher,
+            logger,
+            visualStyleStore);
+        var viewModel = new MainViewModel(
+            workspace.DrawerService,
+            workspace.TodoService,
+            launcher,
+            logger,
+            quickPanel,
+            new UpdateService(logger),
+            visualStyleStore,
+            new BoxPositionLockStateStore(workspace.DrawerService, logger));
+        await viewModel.LoadAsync();
+
+        viewModel.SelectedBox = Assert.Single(
+            viewModel.Boxes,
+            box => box.Id == workspace.TodoBox.Id);
+        await viewModel.ReloadItemsFromDesktopAsync();
+
+        Assert.True(viewModel.IsSelectedTodoBox);
+        Assert.False(viewModel.CanImportFiles);
+        Assert.Empty(viewModel.Items);
+        Assert.Equal(
+            "主面板任务",
+            Assert.Single(viewModel.TodoBoxDetail.ActiveTodos).Title);
+
+        viewModel.SelectedBox = Assert.Single(
+            viewModel.Boxes,
+            box => box.Type == BoxType.Normal);
+        await viewModel.ReloadItemsFromDesktopAsync();
+
+        Assert.False(viewModel.IsSelectedTodoBox);
+        Assert.True(viewModel.CanImportFiles);
+        Assert.Null(viewModel.TodoBoxDetail.BoxId);
+    }
+
+    private sealed class TodoWorkspace : IDisposable
+    {
+        private TodoWorkspace(
+            string root,
+            DrawerService drawerService,
+            TodoService todoService,
+            Box todoBox)
+        {
+            Root = root;
+            DrawerService = drawerService;
+            TodoService = todoService;
+            TodoBox = todoBox;
+        }
+
+        public string Root { get; }
+
+        public DrawerService DrawerService { get; }
+
+        public TodoService TodoService { get; }
+
+        public Box TodoBox { get; }
+
+        public static async Task<TodoWorkspace> CreateAsync()
+        {
+            var root = Path.Combine(
+                Path.GetTempPath(),
+                "WitchDrawer.TodoDetailTests",
+                Guid.NewGuid().ToString("N"));
+            var paths = new AppPaths(root);
+            var repository = new DrawerRepository(paths.DatabasePath);
+            var drawerService = new DrawerService(paths, repository);
+            await drawerService.InitializeAsync();
+            var todoBox = await drawerService.CreateBoxAsync(
+                "待办收纳盒",
+                BoxType.Todo);
+
+            return new TodoWorkspace(
+                root,
+                drawerService,
+                new TodoService(repository),
+                todoBox);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(Root))
+                {
+                    Directory.Delete(Root, recursive: true);
+                }
+            }
+            catch
+            {
+                // Temp cleanup should not hide the test result.
+            }
+        }
+    }
+
+    private sealed class RecordingLogger : IAppLogger
+    {
+        public void Info(string message)
+        {
+        }
+
+        public void Error(Exception exception, string message)
+        {
+        }
+    }
+
+    private sealed class NoOpFileLauncher : IFileLauncher
+    {
+        public Task OpenAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/WitchDrawer.App.Tests/TodoBoxDetailViewModelTests.cs
+++ b/tests/WitchDrawer.App.Tests/TodoBoxDetailViewModelTests.cs
@@ -6,7 +6,6 @@ using WitchDrawer.Core.Abstractions;
 using WitchDrawer.Core.Logging;
 using WitchDrawer.Core.Models;
 using WitchDrawer.Core.Services;
-using WitchDrawer.Core.Storage;
 
 namespace WitchDrawer.App.Tests;
 
@@ -119,7 +118,7 @@ public sealed class TodoBoxDetailViewModelTests
             launcher,
             logger,
             quickPanel,
-            new UpdateService(logger),
+            new RustUpdateService(workspace.DrawerService, logger),
             visualStyleStore,
             new BoxPositionLockStateStore(workspace.DrawerService, logger));
         await viewModel.LoadAsync();
@@ -150,8 +149,8 @@ public sealed class TodoBoxDetailViewModelTests
     {
         private TodoWorkspace(
             string root,
-            DrawerService drawerService,
-            TodoService todoService,
+            RustDrawerService drawerService,
+            ITodoService todoService,
             Box todoBox)
         {
             Root = root;
@@ -162,9 +161,9 @@ public sealed class TodoBoxDetailViewModelTests
 
         public string Root { get; }
 
-        public DrawerService DrawerService { get; }
+        public RustDrawerService DrawerService { get; }
 
-        public TodoService TodoService { get; }
+        public ITodoService TodoService { get; }
 
         public Box TodoBox { get; }
 
@@ -175,8 +174,7 @@ public sealed class TodoBoxDetailViewModelTests
                 "WitchDrawer.TodoDetailTests",
                 Guid.NewGuid().ToString("N"));
             var paths = new AppPaths(root);
-            var repository = new DrawerRepository(paths.DatabasePath);
-            var drawerService = new DrawerService(paths, repository);
+            var drawerService = new RustDrawerService(paths.RootDirectory);
             await drawerService.InitializeAsync();
             var todoBox = await drawerService.CreateBoxAsync(
                 "待办收纳盒",
@@ -185,12 +183,17 @@ public sealed class TodoBoxDetailViewModelTests
             return new TodoWorkspace(
                 root,
                 drawerService,
-                new TodoService(repository),
+                new RustTodoService(drawerService),
                 todoBox);
         }
 
         public void Dispose()
         {
+            if (DrawerService is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+
             try
             {
                 if (Directory.Exists(Root))


### PR DESCRIPTION
## 这个PR做了什么

本 PR 将上游 `main` 分支（C# 主线）v1.1.8 的更新移植到 Rust 分支（`main-rust`），让 Rust 分支与 MAIN 分支保持同步，

## 同步内容

| 上游 main 提交 | 说明 |
|---|---|
| `67915ff` release: 发布 v1.1.8 | 版本号 1.1.7 → 1.1.8（Directory.Build.props / README / installer） |
| `e3fb765` feat: refine drawer UI and box customization | Box 视觉样式（Modern/Pixel）定制 + 位置锁定状态持久化，22 文件 +2062 行 |
| `1ea8184` feat: add dedicated todo box workspace | 独立待办桌面盒工作区 + 详情视图，8 文件 +1163 行 |

已同步覆盖：

- `6577827` fix: 修复开机静默启动 — `StartupShortcutMigration.cs` 内容与 main-rust 一致（MD5 相同）
- `798362a` docs: 项目展示图片 — main-rust 已有等价提交

## Rust 适配

新增功能代码适配 Rust 服务接口：

- `BoxVisualStyleStore` / `BoxPositionLockStateStore` / `TodoBoxDetailViewModel` 使用 `IDrawerService` / `ITodoService` / `IUpdateService` 接口而非 C# 具体类
- `MaximumTitleLength` 用字面量 200
- 新测试改用 `RustDrawerService` + 临时目录 workspace 模式

## 验收测试

执行

```powershell
.\build.ps1 -Release
```

- [x] Rust 构建通过（cargo fmt / clippy warnings-denied / build --release）
- [x] .NET Release 构建通过，0 个警告，0 个错误
- [x] 142 个 .NET 测试通过（App 77 + Core 53 + Native 12）
- [x] Rust 测试通过
- [x] 应用启动实测正常（WitchDrawer.App.exe 运行稳定）
- [x] 上游 main-rust 文件零缺失，fork/main 完全包含
