### PR TITLE
fix: primary button hover/active keeps readable opaque accent

### DIFF
--- a/src/WitchDrawer.App/App.xaml
+++ b/src/WitchDrawer.App/App.xaml
@@ -25,6 +25,10 @@
         <SolidColorBrush x:Key="TextPrimaryBrush" Color="{StaticResource TextPrimaryColor}" />
         <SolidColorBrush x:Key="TextMutedBrush" Color="{StaticResource TextMutedColor}" />
         <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
+        <!-- 悬停态实色加深(方案A);运行时由 AppThemeManager 按主题覆盖 -->
+        <SolidColorBrush x:Key="AccentHoverBrush" Color="#0066D6" />
+        <!-- 按下态进一步加深 -->
+        <SolidColorBrush x:Key="AccentPressedBrush" Color="#0052B3" />
         <SolidColorBrush x:Key="AccentSoftBrush" Color="{StaticResource AccentSoftColor}" />
         <SolidColorBrush x:Key="GlassSurfaceBrush" Color="#FFFFFF" />
         <SolidColorBrush x:Key="GlassInnerBrush" Color="#FAFAFC" />
@@ -114,12 +118,66 @@
             <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
             <Setter Property="Foreground" Value="White" />
             <Setter Property="FontWeight" Value="SemiBold" />
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
-                    <Setter Property="Opacity" Value="0.88" />
-                </Trigger>
-            </Style.Triggers>
+            <!-- 独立模板:悬停/按下用实色变体,不被默认模板的 HoverBrush/Opacity 覆盖 -->
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type Button}">
+                        <Border x:Name="Root"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="10"
+                                Padding="{TemplateBinding Padding}"
+                                RenderTransformOrigin="0.5,0.5">
+                            <Border.RenderTransform>
+                                <ScaleTransform x:Name="RootScale" ScaleX="1" ScaleY="1" />
+                            </Border.RenderTransform>
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"
+                                              RecognizesAccessKey="True" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <EventTrigger RoutedEvent="MouseEnter">
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="RootScale"
+                                                         Storyboard.TargetProperty="ScaleX"
+                                                         To="1.025"
+                                                         Duration="0:0:0.1" />
+                                        <DoubleAnimation Storyboard.TargetName="RootScale"
+                                                         Storyboard.TargetProperty="ScaleY"
+                                                         To="1.025"
+                                                         Duration="0:0:0.1" />
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </EventTrigger>
+                            <EventTrigger RoutedEvent="MouseLeave">
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="RootScale"
+                                                         Storyboard.TargetProperty="ScaleX"
+                                                         To="1"
+                                                         Duration="0:0:0.12" />
+                                        <DoubleAnimation Storyboard.TargetName="RootScale"
+                                                         Storyboard.TargetProperty="ScaleY"
+                                                         To="1"
+                                                         Duration="0:0:0.12" />
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </EventTrigger>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Root" Property="Background" Value="{DynamicResource AccentHoverBrush}" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="Root" Property="Background" Value="{DynamicResource AccentPressedBrush}" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="Root" Property="Opacity" Value="0.5" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
         </Style>
 
         <Style x:Key="DangerButtonStyle" TargetType="{x:Type Button}" BasedOn="{StaticResource {x:Type Button}}">

--- a/src/WitchDrawer.App/Infrastructure/AppThemeManager.cs
+++ b/src/WitchDrawer.App/Infrastructure/AppThemeManager.cs
@@ -54,6 +54,8 @@ public static class AppThemeManager
             SetColor("TextPrimaryBrush", "#F3F4F6");     // High contrast silver-white text
             SetColor("TextMutedBrush", "#9CA3AF");       // Muted silver text
             SetColor("AccentBrush", "#3B82F6");          // Clear blue accent
+            SetColor("AccentHoverBrush", "#2B6FE0");     // Deeper accent on hover (opaque)
+            SetColor("AccentPressedBrush", "#1F5CC9");   // Deepest accent on press (opaque)
             SetColor("AccentSoftBrush", "#333B82F6");     // Translucent selection highlight
             SetColor("GlassSurfaceBrush", "#B3121218");  // Floating desktop box surface
             SetColor("GlassInnerBrush", "#1AFFFFFF");     // File icon container backplate
@@ -77,6 +79,8 @@ public static class AppThemeManager
             SetColor("TextPrimaryBrush", "#111827");      // Dark slate text
             SetColor("TextMutedBrush", "#4B5563");        // Muted slate text
             SetColor("AccentBrush", "#0EA5E9");           // Clear Sky Blue
+            SetColor("AccentHoverBrush", "#0B8AC7");     // Deeper sky blue on hover (opaque)
+            SetColor("AccentPressedBrush", "#0977AE");   // Deepest sky blue on press (opaque)
             SetColor("AccentSoftBrush", "#400EA5E9");     // Translucent Sky Blue tint
             SetColor("GlassSurfaceBrush", "#A6FFFFFF");   // Readable floating surface
             SetColor("GlassInnerBrush", "#73FFFFFF");     // Quiet inner glass
@@ -100,6 +104,8 @@ public static class AppThemeManager
             SetColor("TextPrimaryBrush", "#111827");      // Slate primary text
             SetColor("TextMutedBrush", "#6B7280");        // Slate muted text
             SetColor("AccentBrush", "#007AFF");           // Clean system blue
+            SetColor("AccentHoverBrush", "#0066D6");     // Deeper system blue on hover (opaque)
+            SetColor("AccentPressedBrush", "#0052B3");   // Deepest system blue on press (opaque)
             SetColor("AccentSoftBrush", "#EAF3FF");        // Soft blue tint
             SetColor("GlassSurfaceBrush", "#FBFBFD");     // Light floating box surface
             SetColor("GlassInnerBrush", "#F3F4F6");       // Light icon container backplate


### PR DESCRIPTION
## 这个PR做了什么

修复主按钮(PrimaryButtonStyle)悬停/按下时配色异常问题。详见 Issue #5。

## 根因

默认 Button 模板的 `IsMouseOver` 触发器把 Background 设为 `HoverBrush`,而 **ControlTemplate 触发器优先级高于样式触发器**,导致 PrimaryButtonStyle 的悬停设置被覆盖:

| 主题 | HoverBrush | 悬停实际表现 |
|---|---|---|
| 清透雅致 Moe | `#F3F4F6` 浅灰白 | 背景发白 |
| 暗黑曜石 Glass | `#1FFFFFFF` 白 12% 透明 | 背景透明 |
| 全透水晶 Crystal | `#80FFFFFF` 白 50% 透明 | 背景透明 |

白色文字在透明/浅色背景上难以识别,所有使用 PrimaryButtonStyle 的按钮(共 5 处)都受影响。

## 修复方案

给 `PrimaryButtonStyle` 提供**独立 ControlTemplate**(不被默认模板覆盖):

- `IsMouseOver` → `AccentHoverBrush`(主题 AccentBrush 的加深实色)
- `IsPressed` → `AccentPressedBrush`(进一步加深实色)
- 禁用态仍用 Opacity 0.5

`AppThemeManager` 为三个主题(Moe/Glass/Crystal)注册各自的 `AccentHoverBrush` / `AccentPressedBrush`:

| 主题 | 默认 | 悬停 | 按下 |
|---|---|---|---|
| 清透雅致 | #007AFF | #0066D6 | #0052B3 |
| 暗黑曜石 | #3B82F6 | #2B6FE0 | #1F5CC9 |
| 全透水晶 | #0EA5E9 | #0B8AC7 | #0977AE |

## 验收测试

- [x] `dotnet build WitchDrawer.sln` 0 警告 0 错误
- [x] 三主题下悬停/按下确认按钮:深蓝实底、白字清晰

Fixes #5
