### PR TITLE
feat: 完善布局/透明度/文件名显示，新增右键菜单、重命名、合并、一键分类与多屏防重叠

### DIFF
--- a/src/WitchDrawer.App/Infrastructure/AppThemeManager.cs
+++ b/src/WitchDrawer.App/Infrastructure/AppThemeManager.cs
@@ -37,9 +37,17 @@ public static class AppThemeManager
 
     public static event EventHandler<bool>? CrystalBoxTransparencyChanged;
 
+    public static event EventHandler<double>? BoxBackgroundOpacityChanged;
+
     public static AppTheme CurrentTheme => _currentTheme;
 
     public static bool UseTransparentCrystalBoxes => _useTransparentCrystalBoxes;
+
+    /// <summary>
+    /// 0.05..1.0 multiplier applied to the desktop-box glass brush alphas.
+    /// 1.0 keeps the theme's authored opacity; lower values make boxes more see-through.
+    /// </summary>
+    public static double BoxBackgroundOpacity { get; private set; } = 1.0;
 
     public static void Apply(AppTheme theme)
     {
@@ -136,6 +144,18 @@ public static class AppThemeManager
 
         _useTransparentCrystalBoxes = enabled;
         CrystalBoxTransparencyChanged?.Invoke(null, enabled);
+    }
+
+    public static void SetBoxBackgroundOpacity(double opacity)
+    {
+        var normalized = double.IsFinite(opacity) ? Math.Clamp(opacity, 0.05, 1.0) : 1.0;
+        if (Math.Abs(BoxBackgroundOpacity - normalized) < 0.001)
+        {
+            return;
+        }
+
+        BoxBackgroundOpacity = normalized;
+        BoxBackgroundOpacityChanged?.Invoke(null, normalized);
     }
 
     public static void ApplyDesktopBoxResources(ResourceDictionary resources)

--- a/src/WitchDrawer.App/Infrastructure/DesktopBoxManager.cs
+++ b/src/WitchDrawer.App/Infrastructure/DesktopBoxManager.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Windows;
 using CommunityToolkit.Mvvm.Messaging;
@@ -63,6 +64,9 @@ public sealed class DesktopBoxManager
         WeakReferenceMessenger.Default.Register<DesktopBoxManager, BoxTitleVisibilityChangedMessage>(
             this,
             static (recipient, message) => recipient.ApplyTitleVisibility(message));
+        WeakReferenceMessenger.Default.Register<DesktopBoxManager, BoxItemNameVisibilityChangedMessage>(
+            this,
+            static (recipient, message) => recipient.ApplyItemNameVisibility(message));
         WeakReferenceMessenger.Default.Register<DesktopBoxManager, DrawerSortModeChangedMessage>(
             this,
             static (recipient, message) => recipient.ApplyDrawerSortMode(message));
@@ -135,6 +139,8 @@ public sealed class DesktopBoxManager
                         layoutSettings);
                     await viewModel.LoadDrawerCoverSizeAsync();
                     await viewModel.LoadTitleVisibilityAsync();
+                    await viewModel.LoadItemNameVisibilityAsync();
+                    await viewModel.LoadMaxRowsAsync();
                     await viewModel.LoadDrawerSortModeAsync();
                     viewModel.ItemsChanged += (_, _) => ItemsChanged?.Invoke(this, EventArgs.Empty);
 
@@ -455,6 +461,15 @@ public sealed class DesktopBoxManager
         }
     }
 
+    private void ApplyItemNameVisibility(
+        BoxItemNameVisibilityChangedMessage message)
+    {
+        if (_windows.TryGetValue(message.BoxId, out var window))
+        {
+            window.ViewModel.ApplyItemNameVisibility(message.IsVisible);
+        }
+    }
+
     private void ApplyDrawerSortMode(DrawerSortModeChangedMessage message)
     {
         if (_windows.TryGetValue(message.BoxId, out var window))
@@ -463,22 +478,207 @@ public sealed class DesktopBoxManager
         }
     }
 
-    private async Task PlaceWindowAsync(Window window, Guid boxId, int fallbackIndex)
+    private async Task PlaceWindowAsync(DesktopBoxWindow window, Guid boxId, int fallbackIndex)
     {
         // SizeToContent windows report NaN for Width/Height before they are shown; measure
         // first and use DesiredSize so saved positions are restored correctly.
         window.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
 
         var savedPosition = await _drawerService.GetSettingAsync(BoxPositionSettingPrefix + boxId.ToString("N"));
-        if (TryParsePosition(savedPosition, out var left, out var top))
+        var workAreas = GetMonitorWorkAreasDip(window);
+        var primaryWorkArea = workAreas.Count > 0 ? workAreas[0] : SystemParameters.WorkArea;
+
+        double left;
+        double top;
+        if (TryParsePosition(savedPosition, out var savedLeft, out var savedTop))
         {
-            var workArea = SystemParameters.WorkArea;
-            window.Left = Math.Max(workArea.Left, Math.Min(left, workArea.Right - window.DesiredSize.Width));
-            window.Top = Math.Max(workArea.Top, Math.Min(top, workArea.Bottom - window.DesiredSize.Height));
-            return;
+            (left, top) = ClampToContainingWorkArea(
+                savedLeft,
+                savedTop,
+                window.DesiredSize,
+                workAreas,
+                primaryWorkArea);
+        }
+        else
+        {
+            (left, top) = PlaceNewWindowCore(window, fallbackIndex, primaryWorkArea);
         }
 
-        PlaceNewWindow(window, fallbackIndex);
+        // Anti-overlap: a saved position may collide with another box (e.g. after a
+        // monitor was unplugged and several boxes were clamped onto the same screen).
+        // Cascade the window to a nearby free spot instead of stacking it.
+        (left, top) = FindNonOverlappingPosition(window, left, top, workAreas, primaryWorkArea);
+
+        window.Left = left;
+        window.Top = top;
+    }
+
+    private (double Left, double Top) FindNonOverlappingPosition(
+        DesktopBoxWindow window,
+        double left,
+        double top,
+        IReadOnlyList<Rect> workAreas,
+        Rect primaryWorkArea)
+    {
+        const double gap = 12;
+        const double margin = 8;
+        var width = NormalizeDimension(window.DesiredSize.Width);
+        var height = NormalizeDimension(window.DesiredSize.Height);
+
+        var placedRects = _windows.Values
+            .Where(candidate => candidate != window && candidate.IsVisible)
+            .Select(candidate => new Rect(
+                candidate.Left,
+                candidate.Top,
+                Math.Max(1, candidate.ActualWidth),
+                Math.Max(1, candidate.ActualHeight)))
+            .ToArray();
+        if (placedRects.Length == 0)
+        {
+            return (left, top);
+        }
+
+        var workArea = FindContainingWorkArea(left, top, width, height, workAreas, primaryWorkArea);
+        var rect = new Rect(left, top, width, height);
+        if (placedRects.All(placed => !placed.IntersectsWith(rect)))
+        {
+            return (left, top);
+        }
+
+        var cascadeLeft = workArea.Left + margin;
+        var cascadeTop = workArea.Top + margin;
+        var currentLeft = cascadeLeft;
+        var currentTop = cascadeTop;
+
+        // Try the whole work area grid before giving up; afterwards accept the last
+        // candidate so a fully saturated screen still places the window.
+        for (var attempt = 0; attempt < 200; attempt++)
+        {
+            rect = new Rect(currentLeft, currentTop, width, height);
+            if (placedRects.All(placed => !placed.IntersectsWith(rect)))
+            {
+                return (currentLeft, currentTop);
+            }
+
+            currentLeft += width + gap;
+            if (currentLeft + width > workArea.Right - margin)
+            {
+                currentLeft = cascadeLeft;
+                currentTop += height + gap;
+            }
+
+            if (currentTop + height > workArea.Bottom - margin)
+            {
+                currentTop = cascadeTop;
+            }
+        }
+
+        return (left, top);
+    }
+
+    private static (double Left, double Top) ClampToContainingWorkArea(
+        double left,
+        double top,
+        Size windowSize,
+        IReadOnlyList<Rect> workAreas,
+        Rect primaryWorkArea)
+    {
+        var workArea = FindContainingWorkArea(left, top, windowSize.Width, windowSize.Height, workAreas, primaryWorkArea);
+        return (
+            Math.Max(workArea.Left, Math.Min(left, workArea.Right - windowSize.Width)),
+            Math.Max(workArea.Top, Math.Min(top, workArea.Bottom - windowSize.Height)));
+    }
+
+    private static double NormalizeDimension(double value)
+    {
+        return double.IsFinite(value) && value > 1 ? value : 1;
+    }
+
+    private static Rect FindContainingWorkArea(
+        double left,
+        double top,
+        double width,
+        double height,
+        IReadOnlyList<Rect> workAreas,
+        Rect primaryWorkArea)
+    {
+        if (workAreas.Count == 0)
+        {
+            return primaryWorkArea;
+        }
+
+        // Prefer the work area containing the window center; fall back to the
+        // area with the largest intersection, then the primary screen.
+        var centerX = left + width / 2;
+        var centerY = top + height / 2;
+        var centerContaining = workAreas.FirstOrDefault(area => area.Contains(centerX, centerY));
+        if (centerContaining != default)
+        {
+            return centerContaining;
+        }
+
+        var windowRect = new Rect(left, top, Math.Max(1, width), Math.Max(1, height));
+        var bestIntersection = double.MinValue;
+        var bestArea = primaryWorkArea;
+        foreach (var area in workAreas)
+        {
+            var intersection = Rect.Intersect(area, windowRect);
+            var areaValue = intersection == Rect.Empty ? -1 : intersection.Width * intersection.Height;
+            if (areaValue > bestIntersection)
+            {
+                bestIntersection = areaValue;
+                bestArea = area;
+            }
+        }
+
+        return bestArea;
+    }
+
+    /// <summary>
+    /// Enumerates every monitor's work area and converts it to DIP using the
+    /// window's DPI scale. Monitors are ordered primary-first.
+    /// </summary>
+    private static IReadOnlyList<Rect> GetMonitorWorkAreasDip(Window window)
+    {
+        var scale = 1.0;
+        try
+        {
+            var dpi = System.Windows.Media.VisualTreeHelper.GetDpi(window);
+            scale = Math.Max(0.1, dpi.DpiScaleX);
+        }
+        catch
+        {
+            // Fall back to unscaled physical pixels.
+        }
+
+        var monitors = new List<(NativeRect Work, bool IsPrimary)>();
+
+        bool EnumMonitorCallback(
+            nint monitorHandle,
+            nint hdcMonitor,
+            ref NativeRect monitorRect,
+            nint data)
+        {
+            var info = new MonitorInfo { CbSize = Marshal.SizeOf<MonitorInfo>() };
+            if (GetMonitorInfo(monitorHandle, ref info))
+            {
+                monitors.Add((info.RcWork, (info.DwFlags & MonitorInfoPrimary) != 0));
+            }
+
+            return true;
+        }
+
+        EnumDisplayMonitors(nint.Zero, nint.Zero, EnumMonitorCallback, nint.Zero);
+
+        var ordered = monitors
+            .OrderByDescending(monitor => monitor.IsPrimary)
+            .Select(monitor => new Rect(
+                monitor.Work.Left / scale,
+                monitor.Work.Top / scale,
+                (monitor.Work.Right - monitor.Work.Left) / scale,
+                (monitor.Work.Bottom - monitor.Work.Top) / scale))
+            .ToList();
+        return ordered;
     }
 
     private static bool TryParsePosition(string? raw, out double left, out double top)
@@ -501,17 +701,27 @@ public sealed class DesktopBoxManager
 
     private static void PlaceNewWindow(Window window, int index)
     {
+        var (left, top) = PlaceNewWindowCore(window, index, SystemParameters.WorkArea);
+        window.Left = left;
+        window.Top = top;
+    }
+
+    private static (double Left, double Top) PlaceNewWindowCore(
+        Window window,
+        int index,
+        Rect workArea)
+    {
         const double margin = 18;
         const double gap = 12;
         const double topPadding = 84;
 
-        var workArea = SystemParameters.WorkArea;
         var centerX = workArea.Left + (workArea.Width - window.DesiredSize.Width) / 2;
         var centerY = workArea.Top + (workArea.Height - window.DesiredSize.Height) / 2;
 
         var offset = index * (window.DesiredSize.Width + gap);
-        window.Left = Math.Max(workArea.Left + margin, Math.Min(centerX + offset, workArea.Right - window.DesiredSize.Width - margin));
-        window.Top = Math.Max(workArea.Top + margin, Math.Min(centerY + topPadding * 0.5, workArea.Bottom - window.DesiredSize.Height - margin));
+        var left = Math.Max(workArea.Left + margin, Math.Min(centerX + offset, workArea.Right - window.DesiredSize.Width - margin));
+        var top = Math.Max(workArea.Top + margin, Math.Min(centerY + topPadding * 0.5, workArea.Bottom - window.DesiredSize.Height - margin));
+        return (left, top);
     }
 
     private void OnWindowLocationChanged(object? sender, EventArgs e)
@@ -755,4 +965,40 @@ public sealed class DesktopBoxManager
             Math.Max(0, window.ActualWidth - margin.Left - margin.Right),
             Math.Max(0, window.ActualHeight - margin.Top - margin.Bottom));
     }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeRect
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct MonitorInfo
+    {
+        public int CbSize;
+        public NativeRect RcMonitor;
+        public NativeRect RcWork;
+        public uint DwFlags;
+    }
+
+    private const uint MonitorInfoPrimary = 1;
+
+    private delegate bool MonitorEnumProc(
+        nint monitorHandle,
+        nint hdcMonitor,
+        ref NativeRect monitorRect,
+        nint data);
+
+    [DllImport("user32.dll")]
+    private static extern bool EnumDisplayMonitors(
+        nint hdc,
+        nint clipRect,
+        MonitorEnumProc callback,
+        nint data);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern bool GetMonitorInfo(nint monitorHandle, ref MonitorInfo info);
 }

--- a/src/WitchDrawer.App/Infrastructure/ShellIconProvider.cs
+++ b/src/WitchDrawer.App/Infrastructure/ShellIconProvider.cs
@@ -103,7 +103,8 @@ public static class ShellIconProvider
 
     private static ImageSource? GetIcon(string fullPath, bool isDirectory, int size)
     {
-        if (!isDirectory && IsShortcut(fullPath))
+        var isShortcut = !isDirectory && IsShortcut(fullPath);
+        if (isShortcut)
         {
             foreach (var candidate in GetShortcutIconCandidates(fullPath))
             {
@@ -115,6 +116,10 @@ public static class ShellIconProvider
             }
         }
 
+        // IShellItemImageFactory with IconOnly renders the item icon without the
+        // shortcut arrow overlay, so shortcuts can still use it for the best
+        // quality icon. Only the SHGetFileInfo fallback below (whose .lnk icon
+        // is the arrowed generic shortcut glyph) is replaced with a clean icon.
         var shellItemIcon = TryGetShellItemIcon(fullPath, size);
         if (shellItemIcon is not null)
         {
@@ -124,13 +129,23 @@ public static class ShellIconProvider
         var attributes = isDirectory ? FileAttributeDirectory : FileAttributeNormal;
         var flags = GetIconFlags(size);
 
-        if (!File.Exists(fullPath) && !Directory.Exists(fullPath))
+        var iconPath = fullPath;
+        if (isShortcut)
+        {
+            // SHGFI_USEFILEATTRIBUTES makes SHGetFileInfo key off the extension
+            // only, so a placeholder ".exe" path yields a generic application
+            // icon without the shortcut arrow.
+            var baseDirectory = Path.GetDirectoryName(fullPath) ?? string.Empty;
+            iconPath = Path.Combine(baseDirectory, "WitchDrawerGenericIcon.exe");
+            flags |= ShgfiUseFileAttributes;
+        }
+        else if (!File.Exists(fullPath) && !Directory.Exists(fullPath))
         {
             flags |= ShgfiUseFileAttributes;
         }
 
-        return GetIcon(fullPath, attributes, flags, size)
-            ?? GetIcon(fullPath, attributes, flags | ShgfiUseFileAttributes, size);
+        return GetIcon(iconPath, attributes, flags, size)
+            ?? GetIcon(iconPath, attributes, flags | ShgfiUseFileAttributes, size);
     }
 
     private static uint GetIconFlags(int size)

--- a/src/WitchDrawer.App/MainWindow.xaml
+++ b/src/WitchDrawer.App/MainWindow.xaml
@@ -783,6 +783,38 @@
                                                   Visibility="{Binding SelectedBox.IsTitleVisible, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
                                         </Grid>
                                     </Button>
+
+                                    <Button Width="34"
+                                            Height="34"
+                                            MinWidth="34"
+                                            MinHeight="34"
+                                            Margin="4,0,0,0"
+                                            Padding="0"
+                                            Command="{Binding SelectedBox.ToggleItemNameVisibilityCommand}"
+                                            ToolTip="{Binding SelectedBox.ItemNameVisibilityToolTip}"
+                                            Style="{StaticResource GhostButtonStyle}">
+                                        <Grid Width="20" Height="16">
+                                            <Border BorderBrush="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                                    BorderThickness="1.1"
+                                                    CornerRadius="2"
+                                                    Width="14"
+                                                    Height="12"
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center" />
+                                            <TextBlock Text="Aa"
+                                                       FontSize="8.5"
+                                                       FontWeight="Bold"
+                                                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center" />
+                                            <Path Data="M 1,1 L 19,15"
+                                                  Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                                  StrokeThickness="1.6"
+                                                  StrokeStartLineCap="Round"
+                                                  StrokeEndLineCap="Round"
+                                                  Visibility="{Binding SelectedBox.IsItemNameVisible, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                                        </Grid>
+                                    </Button>
                                 </StackPanel>
                             </StackPanel>
 
@@ -2223,6 +2255,126 @@
                                                 Style="{StaticResource CrystalThemeChoiceButtonStyle}" />
                                     </UniformGrid>
                                 </Grid>
+                                </Border>
+
+                                <!-- Box Appearance & Organization Card -->
+                                <Border Background="{DynamicResource PanelBrush}"
+                                    BorderBrush="{DynamicResource BorderBrushSoft}"
+                                    BorderThickness="1"
+                                    CornerRadius="12"
+                                    Padding="10"
+                                    Margin="0,0,0,6">
+                                <StackPanel>
+                                    <TextBlock Text="收纳盒外观与整理"
+                                               FontWeight="SemiBold"
+                                               FontSize="13"
+                                               Foreground="{DynamicResource TextPrimaryBrush}" />
+
+                                    <!-- 背景透明度滑块 -->
+                                    <Grid Margin="0,10,0,0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="背景不透明度"
+                                                   FontSize="11.5"
+                                                   Foreground="{DynamicResource TextMutedBrush}"
+                                                   VerticalAlignment="Center" />
+                                        <Slider Grid.Column="1"
+                                                Minimum="5"
+                                                Maximum="100"
+                                                TickFrequency="5"
+                                                IsSnapToTickEnabled="True"
+                                                Margin="12,0"
+                                                VerticalAlignment="Center"
+                                                Value="{Binding BoxOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                LostMouseCapture="OnBoxOpacitySliderLostMouseCapture"
+                                                ToolTip="调节桌面收纳盒玻璃背景的透明度" />
+                                        <TextBlock Grid.Column="2"
+                                                   Text="{Binding BoxOpacity, StringFormat={}{0}%}"
+                                                   FontSize="11.5"
+                                                   FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource AccentBrush}"
+                                                   VerticalAlignment="Center"
+                                                   MinWidth="36"
+                                                   TextAlignment="Right" />
+                                    </Grid>
+                                    <TextBlock Text="图标与文字保持不透明，仅背景玻璃变化。"
+                                               FontSize="10.5"
+                                               Foreground="{DynamicResource TextMutedBrush}"
+                                               Margin="0,2,0,0" />
+
+                                    <!-- 一键分类 -->
+                                    <Grid Margin="0,12,0,0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel VerticalAlignment="Center">
+                                            <TextBlock Text="一键分类映射"
+                                                       FontSize="12"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource TextPrimaryBrush}" />
+                                            <TextBlock Text="将各盒中的路径引用按类型（图片/文档/视频/音频/压缩包）归入自动创建的分类收纳盒"
+                                                       FontSize="10.5"
+                                                       Foreground="{DynamicResource TextMutedBrush}"
+                                                       TextWrapping="Wrap"
+                                                       MaxWidth="300" />
+                                        </StackPanel>
+                                        <Button Grid.Column="1"
+                                                Content="一键分类"
+                                                Command="{Binding ClassifyItemsCommand}"
+                                                Style="{StaticResource PrimaryButtonStyle}"
+                                                Padding="14,6"
+                                                VerticalAlignment="Center" />
+                                    </Grid>
+
+                                    <!-- 合并收纳盒 -->
+                                    <Grid Margin="0,12,0,0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel VerticalAlignment="Center">
+                                            <TextBlock Text="合并收纳盒"
+                                                       FontSize="12"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource TextPrimaryBrush}" />
+                                            <TextBlock Text="把当前选中盒的全部内容并入另一个同类收纳盒，然后删除当前盒"
+                                                       FontSize="10.5"
+                                                       Foreground="{DynamicResource TextMutedBrush}"
+                                                       TextWrapping="Wrap"
+                                                       MaxWidth="300" />
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="1"
+                                                    Orientation="Horizontal"
+                                                    VerticalAlignment="Center">
+                                            <ComboBox x:Name="MergeTargetComboBox"
+                                                      Width="130"
+                                                      Height="30"
+                                                      ItemsSource="{Binding MergeTargets}"
+                                                      DisplayMemberPath="Name"
+                                                      VerticalContentAlignment="Center"
+                                                      Background="{DynamicResource PanelBrush}"
+                                                      BorderBrush="{DynamicResource BorderBrushSoft}"
+                                                      Foreground="{DynamicResource TextPrimaryBrush}"
+                                                      Visibility="{Binding HasMergeTargets, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                            <Button Content="合并"
+                                                    Margin="8,0,0,0"
+                                                    Command="{Binding MergeSelectedBoxCommand}"
+                                                    CommandParameter="{Binding SelectedItem, ElementName=MergeTargetComboBox}"
+                                                    Style="{StaticResource PrimaryButtonStyle}"
+                                                    Padding="14,6"
+                                                    Visibility="{Binding HasMergeTargets, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                            <TextBlock Text="没有可合并的同类型盒"
+                                                       FontSize="10.5"
+                                                       Foreground="{DynamicResource TextMutedBrush}"
+                                                       VerticalAlignment="Center"
+                                                       Visibility="{Binding HasMergeTargets, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                                        </StackPanel>
+                                    </Grid>
+                                </StackPanel>
                                 </Border>
 
                                 <!-- Keyboard Shortcuts Card -->

--- a/src/WitchDrawer.App/MainWindow.xaml.cs
+++ b/src/WitchDrawer.App/MainWindow.xaml.cs
@@ -889,6 +889,12 @@ public partial class MainWindow : Window
         }
     }
 
+    private async void OnBoxOpacitySliderLostMouseCapture(object sender, MouseEventArgs e)
+    {
+        // Persist once the user releases the slider instead of on every tick.
+        await ViewModel.SaveBoxOpacityAsync();
+    }
+
     private void OnOpenProjectLinkClicked(object sender, RoutedEventArgs e)
     {
         OpenExternalUri("https://github.com/witchscottishfoldcat/WitchDrawer");

--- a/src/WitchDrawer.App/Messages/BoxItemNameVisibilityChangedMessage.cs
+++ b/src/WitchDrawer.App/Messages/BoxItemNameVisibilityChangedMessage.cs
@@ -1,0 +1,3 @@
+namespace WitchDrawer.App.Messages;
+
+public sealed record BoxItemNameVisibilityChangedMessage(Guid BoxId, bool IsVisible);

--- a/src/WitchDrawer.App/ViewModels/BoxViewModel.cs
+++ b/src/WitchDrawer.App/ViewModels/BoxViewModel.cs
@@ -12,6 +12,7 @@ public sealed partial class BoxViewModel : ObservableObject
     private BoxVisualStyle _visualStyle;
     private bool _isPositionLocked;
     private bool _isTitleVisible = true;
+    private bool _isItemNameVisible = true;
     private DrawerItemSortMode _drawerItemSortMode = DrawerItemSortMode.Name;
 
     public BoxViewModel(
@@ -44,6 +45,7 @@ public sealed partial class BoxViewModel : ObservableObject
 
         _ = LoadPresetAsync();
         _ = LoadTitleVisibilityAsync();
+        _ = LoadItemNameVisibilityAsync();
         _ = LoadDrawerSortModeAsync();
     }
 
@@ -60,6 +62,9 @@ public sealed partial class BoxViewModel : ObservableObject
 
     internal static string GetLegacyDrawerTitleVisibilitySettingKey(Guid boxId) =>
         $"DrawerTitleVisible:{boxId:N}";
+
+    internal static string GetItemNameVisibilitySettingKey(Guid boxId) =>
+        $"BoxShowItemNames:{boxId:N}";
 
     internal static string GetDrawerSortModeSettingKey(Guid boxId) =>
         $"DrawerSortMode:{boxId:N}";
@@ -79,6 +84,12 @@ public sealed partial class BoxViewModel : ObservableObject
     public bool IsDrawerBox => Type == BoxType.Drawer;
 
     public bool IsTitleVisible => _isTitleVisible;
+
+    public bool IsItemNameVisible => _isItemNameVisible;
+
+    public string ItemNameVisibilityToolTip => IsItemNameVisible
+        ? "隐藏图标下方文件名"
+        : "显示图标下方文件名";
 
     public string TitleVisibilityToolTip => IsTitleVisible ? "隐藏桌面收纳盒名称" : "显示桌面收纳盒名称";
 
@@ -198,6 +209,18 @@ public sealed partial class BoxViewModel : ObservableObject
             new BoxTitleVisibilityChangedMessage(Id, isVisible));
     }
 
+    [CommunityToolkit.Mvvm.Input.RelayCommand]
+    private async Task ToggleItemNameVisibilityAsync()
+    {
+        var isVisible = !IsItemNameVisible;
+        await _drawerService.SetSettingAsync(
+            GetItemNameVisibilitySettingKey(Id),
+            isVisible.ToString());
+        ApplyItemNameVisibility(isVisible);
+        WeakReferenceMessenger.Default.Send(
+            new BoxItemNameVisibilityChangedMessage(Id, isVisible));
+    }
+
     internal async Task LoadTitleVisibilityAsync()
     {
         var saved = await _drawerService.GetSettingAsync(GetTitleVisibilitySettingKey(Id));
@@ -208,6 +231,12 @@ public sealed partial class BoxViewModel : ObservableObject
         }
 
         ApplyTitleVisibility(!bool.TryParse(saved, out var isVisible) || isVisible);
+    }
+
+    internal async Task LoadItemNameVisibilityAsync()
+    {
+        var saved = await _drawerService.GetSettingAsync(GetItemNameVisibilitySettingKey(Id));
+        ApplyItemNameVisibility(!bool.TryParse(saved, out var isVisible) || isVisible);
     }
 
     [CommunityToolkit.Mvvm.Input.RelayCommand]
@@ -265,6 +294,19 @@ public sealed partial class BoxViewModel : ObservableObject
 
         OnPropertyChanged(nameof(TitleVisibilityToolTip));
         OnPropertyChanged(nameof(TitleVisibilityAutomationName));
+    }
+
+    private void ApplyItemNameVisibility(bool isVisible)
+    {
+        if (!SetProperty(
+                ref _isItemNameVisible,
+                isVisible,
+                nameof(IsItemNameVisible)))
+        {
+            return;
+        }
+
+        OnPropertyChanged(nameof(ItemNameVisibilityToolTip));
     }
 }
 

--- a/src/WitchDrawer.App/ViewModels/DesktopBoxViewModel.cs
+++ b/src/WitchDrawer.App/ViewModels/DesktopBoxViewModel.cs
@@ -22,6 +22,8 @@ public sealed class DesktopBoxViewModel : ObservableObject
     private const string TitleVisibilitySettingPrefix = "BoxTitleVisible:";
     private const string LegacyDrawerTitleVisibilitySettingPrefix = "DrawerTitleVisible:";
     private const string DrawerSortModeSettingPrefix = "DrawerSortMode:";
+    private const string ItemNameVisibilitySettingPrefix = "BoxShowItemNames:";
+    private const string MaxRowsSettingPrefix = "BoxMaxRows:";
     private const double DefaultDrawerCoverWidth = 180;
     private const double DefaultDrawerCoverHeight = 112;
     private const double MaximumDrawerCoverDimension = 720;
@@ -50,6 +52,8 @@ public sealed class DesktopBoxViewModel : ObservableObject
     private double _iconDpiScaleY = 1;
     private bool _isDrawerExpanded;
     private bool _isTitleVisible = true;
+    private bool _isItemNameVisible = true;
+    private int? _maxRows;
     private double _drawerCoverWidth = DefaultDrawerCoverWidth;
     private double _drawerCoverHeight = DefaultDrawerCoverHeight;
     private int _drawerCoverColumns = 3;
@@ -75,7 +79,11 @@ public sealed class DesktopBoxViewModel : ObservableObject
         _layoutSettings.PropertyChanged += OnLayoutSettingsChanged;
 
         OpenItemCommand = new AsyncRelayCommand<DrawerItemViewModel?>(OpenItemAsync);
+        OpenItemAsAdminCommand = new AsyncRelayCommand<DrawerItemViewModel?>(OpenItemAsAdminAsync);
+        ShowItemInFolderCommand = new AsyncRelayCommand<DrawerItemViewModel?>(ShowItemInFolderAsync);
         DeleteItemCommand = new AsyncRelayCommand<DrawerItemViewModel?>(DeleteItemAsync);
+        ExportItemToDesktopCommand = new AsyncRelayCommand<DrawerItemViewModel?>(ExportItemToDesktopAsync);
+        SortItemsCommand = new AsyncRelayCommand<DrawerItemSortMode?>(SortItemsAsync);
         RefreshCommand = new AsyncRelayCommand(LoadAsync);
         UseMappingGridModeCommand = new AsyncRelayCommand(() => SetMappingViewModeAsync(useListMode: false));
         UseMappingListModeCommand = new AsyncRelayCommand(() => SetMappingViewModeAsync(useListMode: true));
@@ -103,7 +111,15 @@ public sealed class DesktopBoxViewModel : ObservableObject
 
     public IAsyncRelayCommand<DrawerItemViewModel?> OpenItemCommand { get; }
 
+    public IAsyncRelayCommand<DrawerItemViewModel?> OpenItemAsAdminCommand { get; }
+
+    public IAsyncRelayCommand<DrawerItemViewModel?> ShowItemInFolderCommand { get; }
+
     public IAsyncRelayCommand<DrawerItemViewModel?> DeleteItemCommand { get; }
+
+    public IAsyncRelayCommand<DrawerItemViewModel?> ExportItemToDesktopCommand { get; }
+
+    public IAsyncRelayCommand<DrawerItemSortMode?> SortItemsCommand { get; }
 
     public IAsyncRelayCommand RefreshCommand { get; }
 
@@ -151,6 +167,14 @@ public sealed class DesktopBoxViewModel : ObservableObject
     public bool IsDrawerCollapsed => IsDrawerBox && !IsDrawerExpanded;
 
     public bool IsTitleVisible => _isTitleVisible;
+
+    public bool IsItemNameVisible => _isItemNameVisible;
+
+    public int? MaxRows => _maxRows;
+
+    public double MaxGridCanvasHeight => _maxRows.HasValue
+        ? Math.Max(1, _maxRows.Value) * LayoutSettings.ItemSlotHeight
+        : double.PositiveInfinity;
 
     public bool IsHeaderVisible => !IsDrawerCollapsed || IsTitleVisible;
 
@@ -404,6 +428,11 @@ public sealed class DesktopBoxViewModel : ObservableObject
     public (int Column, int Row) GetAvailableDropSlot(int targetColumn, int targetRow, Guid? movingItemId = null)
     {
         var targetSlot = NormalizeGridSlot(targetColumn, targetRow);
+        // 拖拽落点限制在布局预设列数内（如 3×3 最多第 3 列），避免落点
+        // 被 FindFirstFreeSlot 的换行逻辑弹到远处的下一行。
+        targetSlot = (
+            Math.Min(targetSlot.Column, Math.Max(0, LayoutSettings.Columns - 1)),
+            targetSlot.Row);
         var occupiedSlots = Items
             .Where(item => movingItemId is null || item.Id != movingItemId.Value)
             .Select(item => (item.GridColumn, item.GridRow))
@@ -474,7 +503,10 @@ public sealed class DesktopBoxViewModel : ObservableObject
                     Name,
                     isPixelated,
                     GetIconPixelSize(isPixelated),
-                    _logger);
+                    _logger)
+                {
+                    Owner = this
+                };
                 var itemPosition = positions[items[i].Id];
                 itemViewModel.SetGridPosition(itemPosition.Column, itemPosition.Row, LayoutSettings);
                 Items.Insert(i, itemViewModel);
@@ -794,6 +826,146 @@ public sealed class DesktopBoxViewModel : ObservableObject
         }
     }
 
+    private async Task OpenItemAsAdminAsync(DrawerItemViewModel? item)
+    {
+        if (item is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _drawerService.OpenItemAsAdminAsync(item.Id, _launcher);
+            StatusText = $"已以管理员身份打开 {item.DisplayName}";
+        }
+        catch (Exception exception)
+        {
+            _logger.Error(exception, "Failed to open desktop box item as administrator.");
+            StatusText = exception.Message;
+        }
+    }
+
+    private async Task ShowItemInFolderAsync(DrawerItemViewModel? item)
+    {
+        if (item is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _drawerService.ShowItemInFolderAsync(item.Id, _launcher);
+            StatusText = $"已定位 {item.DisplayName}";
+        }
+        catch (Exception exception)
+        {
+            _logger.Error(exception, "Failed to reveal desktop box item in folder.");
+            StatusText = exception.Message;
+        }
+    }
+
+    /// <summary>
+    /// Renames the drawer display name only; the file on disk is never touched.
+    /// </summary>
+    public async Task<bool> RenameItemAsync(DrawerItemViewModel? item, string? newName)
+    {
+        if (item is null)
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(newName))
+        {
+            StatusText = "名称不能为空";
+            return false;
+        }
+
+        try
+        {
+            await _drawerService.RenameItemAsync(item.Id, newName);
+            await LoadAsync();
+            StatusText = $"已重命名为 {newName.Trim()}";
+            ItemsChanged?.Invoke(this, EventArgs.Empty);
+            return true;
+        }
+        catch (Exception exception)
+        {
+            _logger.Error(exception, "Failed to rename desktop box item.");
+            StatusText = exception.Message;
+            return false;
+        }
+    }
+
+    private async Task ExportItemToDesktopCommandAsync(DrawerItemViewModel? item)
+    {
+        await ExportItemToDesktopAsync(item);
+    }
+
+    /// <summary>
+    /// Re-arranges the free grid so items are ordered by the selected rule
+    /// (name / size / type / modified date), column by column.
+    /// </summary>
+    private async Task SortItemsAsync(DrawerItemSortMode? sortMode)
+    {
+        var mode = sortMode ?? DrawerItemSortMode.Name;
+        if (IsBusy || IsTodoBox)
+        {
+            return;
+        }
+
+        if (IsDrawerBox)
+        {
+            await ApplyDrawerItemSortAsync(mode);
+            StatusText = $"已按{DrawerSortModeLabel(mode)}排序";
+            return;
+        }
+
+        try
+        {
+            IsBusy = true;
+            var snapshot = Items
+                .OrderBy(item => item.GridRow)
+                .ThenBy(item => item.GridColumn)
+                .ToArray();
+            var sorted = SortDrawerItems(snapshot, mode);
+            var reservedSlots = new HashSet<(int Column, int Row)>();
+            var nextColumn = 0;
+            var nextRow = 0;
+            foreach (var item in sorted)
+            {
+                var slot = FindFirstFreeSlot(nextColumn, nextRow, reservedSlots);
+                reservedSlots.Add(slot);
+                await _drawerService.UpdateItemGridPositionAsync(
+                    item.Id,
+                    slot.Column,
+                    slot.Row);
+                item.SetGridPosition(slot.Column, slot.Row, LayoutSettings);
+                nextColumn = slot.Column + 1;
+                nextRow = slot.Row;
+            }
+
+            UpdateGridCanvasSize();
+            StatusText = $"已按{DrawerSortModeLabel(mode)}排序";
+        }
+        catch (Exception exception)
+        {
+            _logger.Error(exception, "Failed to sort desktop box items.");
+            StatusText = exception.Message;
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private static string DrawerSortModeLabel(DrawerItemSortMode mode) => mode switch
+    {
+        DrawerItemSortMode.Size => "大小",
+        DrawerItemSortMode.ItemType => "类型",
+        DrawerItemSortMode.ModifiedDate => "修改日期",
+        _ => "名称"
+    };
+
     private async Task DeleteItemAsync(DrawerItemViewModel? item)
     {
         if (item is null)
@@ -876,18 +1048,28 @@ public sealed class DesktopBoxViewModel : ObservableObject
         int startRow,
         HashSet<(int Column, int Row)> occupiedSlots)
     {
-
         var column = Math.Max(0, startColumn);
         var row = Math.Max(0, startRow);
         var maxOccupiedColumn = occupiedSlots.Count > 0 ? occupiedSlots.Max(s => s.Column) : 0;
-        var wrapColumn = Math.Max(4, Math.Max(column, maxOccupiedColumn));
+
+        // 每行有效列数 = 布局预设列数与已有布局的最大列数中较大者。
+        // 这样自动放置遵循"3×3/4×4/…"预设换行，同时不会压缩手动摆放的超宽布局。
+        var wrapWidth = Math.Max(LayoutSettings.Columns, maxOccupiedColumn + 1);
+        var maxColumnIndex = wrapWidth - 1;
+
+        // 起点超出本行有效范围时先换到下一行开头。
+        while (column > maxColumnIndex)
+        {
+            column -= wrapWidth;
+            row++;
+        }
 
         while (occupiedSlots.Contains((column, row)))
         {
             column++;
-            if (column > wrapColumn)
+            if (column > maxColumnIndex)
             {
-                column = Math.Max(0, startColumn);
+                column = 0;
                 row++;
             }
         }
@@ -923,7 +1105,10 @@ public sealed class DesktopBoxViewModel : ObservableObject
         }
 
         GridCanvasWidth = Math.Max(1, maxCol + 1) * LayoutSettings.ItemSlotWidth;
-        GridCanvasHeight = Math.Max(1, maxRow + 1) * LayoutSettings.ItemSlotHeight;
+        var contentHeight = Math.Max(1, maxRow + 1) * LayoutSettings.ItemSlotHeight;
+        GridCanvasHeight = _maxRows.HasValue
+            ? Math.Min(contentHeight, _maxRows.Value * LayoutSettings.ItemSlotHeight)
+            : contentHeight;
         OnPropertyChanged(nameof(DragPreviewWidth));
         OnPropertyChanged(nameof(DragPreviewHeight));
     }
@@ -988,6 +1173,48 @@ public sealed class DesktopBoxViewModel : ObservableObject
         ApplyTitleVisibility(!bool.TryParse(saved, out var isVisible) || isVisible);
     }
 
+    public async Task LoadItemNameVisibilityAsync()
+    {
+        var saved = await _drawerService.GetSettingAsync(GetItemNameVisibilitySettingKey(BoxId));
+        ApplyItemNameVisibility(!bool.TryParse(saved, out var isVisible) || isVisible);
+    }
+
+    public void ApplyItemNameVisibility(bool isVisible)
+    {
+        if (SetProperty(ref _isItemNameVisible, isVisible, nameof(IsItemNameVisible)))
+        {
+            OnPropertyChanged(nameof(MaxGridCanvasHeight));
+            UpdateGridCanvasSize();
+        }
+    }
+
+    public async Task LoadMaxRowsAsync()
+    {
+        var saved = await _drawerService.GetSettingAsync(GetMaxRowsSettingKey(BoxId));
+        if (int.TryParse(saved, out var maxRows) && maxRows >= 1)
+        {
+            ApplyMaxRows(maxRows);
+        }
+    }
+
+    public void ApplyMaxRows(int? maxRows)
+    {
+        var normalized = maxRows.HasValue ? Math.Max(1, maxRows.Value) : (int?)null;
+        if (!SetProperty(ref _maxRows, normalized, nameof(MaxRows)))
+        {
+            return;
+        }
+
+        OnPropertyChanged(nameof(MaxGridCanvasHeight));
+        UpdateGridCanvasSize();
+    }
+
+    public Task SaveMaxRowsAsync(int? maxRows)
+    {
+        var value = maxRows.HasValue ? maxRows.Value.ToString(CultureInfo.InvariantCulture) : string.Empty;
+        return _drawerService.SetSettingAsync(GetMaxRowsSettingKey(BoxId), value);
+    }
+
     public void ApplyTitleVisibility(bool isVisible)
     {
         if (!SetProperty(
@@ -1046,6 +1273,12 @@ public sealed class DesktopBoxViewModel : ObservableObject
 
     internal static string GetDrawerSortModeSettingKey(Guid boxId) =>
         $"{DrawerSortModeSettingPrefix}{boxId:N}";
+
+    internal static string GetItemNameVisibilitySettingKey(Guid boxId) =>
+        $"{ItemNameVisibilitySettingPrefix}{boxId:N}";
+
+    internal static string GetMaxRowsSettingKey(Guid boxId) =>
+        $"{MaxRowsSettingPrefix}{boxId:N}";
 
     internal static bool TryParseDrawerCoverSize(
         string? value,
@@ -1246,6 +1479,7 @@ public sealed class DesktopBoxViewModel : ObservableObject
         }
 
         UpdateItemIconSizes();
+        OnPropertyChanged(nameof(MaxGridCanvasHeight));
         UpdateGridCanvasSize();
         if (IsDrawerBox && e.PropertyName is nameof(DesktopBoxLayoutSettings.CurrentPreset))
         {

--- a/src/WitchDrawer.App/ViewModels/DrawerItemViewModel.cs
+++ b/src/WitchDrawer.App/ViewModels/DrawerItemViewModel.cs
@@ -48,6 +48,16 @@ public sealed class DrawerItemViewModel : ObservableObject
 
     public DrawerItem Model { get; }
 
+    /// <summary>
+    /// The desktop box view model that owns this item; used by context-menu
+    /// command bindings because ContextMenu lives outside the visual tree.
+    /// </summary>
+    public DesktopBoxViewModel? Owner { get; set; }
+
+    public bool IsFile => Model.ItemKind == ItemKind.File;
+
+    public bool IsDirectory => Model.ItemKind == ItemKind.Directory;
+
     public Guid Id => Model.Id;
 
     public string DisplayName

--- a/src/WitchDrawer.App/ViewModels/MainViewModel.cs
+++ b/src/WitchDrawer.App/ViewModels/MainViewModel.cs
@@ -17,6 +17,7 @@ public sealed class MainViewModel : ObservableObject
     private const double ItemIconSizeDip = 19;
     private const string ThemeSettingKey = "Theme";
     private const string CrystalBoxTransparencySettingKey = "CrystalBoxTransparency";
+    private const string BoxBackgroundOpacitySettingKey = "BoxBackgroundOpacity";
     private const string StartupRegistryKeyName = "WitchDrawer";
 
     private readonly DrawerService _drawerService;
@@ -39,6 +40,7 @@ public sealed class MainViewModel : ObservableObject
     private AppTheme _currentTheme;
     private bool _isTransparentCrystalBoxes;
     private bool _launchOnStartup;
+    private int _boxOpacity = 100;
     private string _updateStatusText = string.Empty;
     private bool _isCheckingUpdate;
     private string? _pendingUpdateSha256;
@@ -95,6 +97,8 @@ public sealed class MainViewModel : ObservableObject
         ApplyMoeThemeCommand = new AsyncRelayCommand(() => ApplyThemeAsync(AppTheme.Moe));
         ApplyGlassThemeCommand = new AsyncRelayCommand(() => ApplyThemeAsync(AppTheme.Glass));
         ApplyCrystalThemeCommand = new AsyncRelayCommand(ApplyCrystalThemeAsync);
+        MergeSelectedBoxCommand = new AsyncRelayCommand<BoxViewModel?>(MergeSelectedBoxAsync, box => box is not null);
+        ClassifyItemsCommand = new AsyncRelayCommand(ClassifyItemsAsync);
         ToggleLaunchOnStartupCommand = new AsyncRelayCommand(ToggleLaunchOnStartupAsync);
         CheckForUpdateCommand = new AsyncRelayCommand(CheckForUpdateAsync);
         ShowDashboardCommand = new RelayCommand(() =>
@@ -179,6 +183,13 @@ public sealed class MainViewModel : ObservableObject
     public IAsyncRelayCommand ApplyGlassThemeCommand { get; }
 
     public IAsyncRelayCommand ApplyCrystalThemeCommand { get; }
+
+    /// <summary>
+    /// Merges the selected box's contents into the given target box.
+    /// </summary>
+    public IAsyncRelayCommand<BoxViewModel?> MergeSelectedBoxCommand { get; }
+
+    public IAsyncRelayCommand ClassifyItemsCommand { get; }
 
     public IAsyncRelayCommand ToggleLaunchOnStartupCommand { get; }
 
@@ -282,6 +293,46 @@ public sealed class MainViewModel : ObservableObject
         private set => SetProperty(ref _launchOnStartup, value);
     }
 
+    /// <summary>
+    /// Desktop box background opacity in percent (5..100).
+    /// </summary>
+    public int BoxOpacity
+    {
+        get => _boxOpacity;
+        set
+        {
+            var normalized = Math.Clamp(value, 5, 100);
+            if (SetProperty(ref _boxOpacity, normalized))
+            {
+                AppThemeManager.SetBoxBackgroundOpacity(normalized / 100.0);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Boxes the selected box can be merged into (same storage category, not itself).
+    /// </summary>
+    public IReadOnlyList<BoxViewModel> MergeTargets
+    {
+        get
+        {
+            var selected = SelectedBox;
+            if (selected is null || selected.IsTodoBox)
+            {
+                return Array.Empty<BoxViewModel>();
+            }
+
+            var selectedIsMapping = selected.Type == BoxType.Mapping;
+            return Boxes
+                .Where(candidate => candidate.Id != selected.Id
+                    && !candidate.IsTodoBox
+                    && (candidate.Type == BoxType.Mapping) == selectedIsMapping)
+                .ToArray();
+        }
+    }
+
+    public bool HasMergeTargets => MergeTargets.Count > 0;
+
     public string UpdateStatusText
     {
         get => _updateStatusText;
@@ -325,6 +376,7 @@ public sealed class MainViewModel : ObservableObject
 
             LaunchOnStartup = ReadStartupRegistry();
             await RestoreCrystalBoxTransparencyAsync();
+            await LoadBoxOpacityAsync();
 
             StatusText = $"{Boxes.Count} 个收纳盒已同步到桌面";
             BoxesChanged?.Invoke(this, EventArgs.Empty);
@@ -656,6 +708,8 @@ public sealed class MainViewModel : ObservableObject
         OnPropertyChanged(nameof(SelectedBox));
         OnPropertyChanged(nameof(IsSelectedTodoBox));
         OnPropertyChanged(nameof(CanImportFiles));
+        OnPropertyChanged(nameof(MergeTargets));
+        OnPropertyChanged(nameof(HasMergeTargets));
         DeleteSelectedBoxCommand.NotifyCanExecuteChanged();
         RenameSelectedBoxCommand.NotifyCanExecuteChanged();
         SetSelectedBoxVisualStyleCommand.NotifyCanExecuteChanged();
@@ -922,6 +976,63 @@ public sealed class MainViewModel : ObservableObject
         await _drawerService.SetSettingAsync(
             CrystalBoxTransparencySettingKey,
             enabled.ToString());
+    }
+
+    private async Task LoadBoxOpacityAsync()
+    {
+        var saved = await _drawerService.GetSettingAsync(BoxBackgroundOpacitySettingKey);
+        if (int.TryParse(saved, out var opacity))
+        {
+            BoxOpacity = Math.Clamp(opacity, 5, 100);
+        }
+
+        AppThemeManager.SetBoxBackgroundOpacity(BoxOpacity / 100.0);
+    }
+
+    public async Task SaveBoxOpacityAsync()
+    {
+        await _drawerService.SetSettingAsync(
+            BoxBackgroundOpacitySettingKey,
+            BoxOpacity.ToString());
+    }
+
+    private async Task MergeSelectedBoxAsync(BoxViewModel? targetBox)
+    {
+        var selected = SelectedBox;
+        if (selected is null || targetBox is null || selected.Id == targetBox.Id)
+        {
+            return;
+        }
+
+        await RunBusyAsync(async () =>
+        {
+            try
+            {
+                var mergedCount = await _drawerService.MergeBoxAsync(selected.Id, targetBox.Id);
+                StatusText = $"已将“{selected.Name}”的 {mergedCount} 项合并到“{targetBox.Name}”";
+            }
+            catch (Exception exception)
+            {
+                // 合并可能已部分完成（源盒删除失败等），无论如何都刷新列表。
+                StatusText = exception.Message;
+            }
+
+            await LoadAsync();
+            ItemsChanged?.Invoke(this, EventArgs.Empty);
+        });
+    }
+
+    private async Task ClassifyItemsAsync()
+    {
+        await RunBusyAsync(async () =>
+        {
+            var result = await _drawerService.ClassifyMappingItemsAsync();
+            StatusText = result.MovedCount > 0
+                ? $"已按类型归类 {result.MovedCount} 项映射引用（{result.SkippedCount} 项无需移动或属于存储文件）"
+                : "没有需要归类的映射引用";
+            await LoadAsync();
+            ItemsChanged?.Invoke(this, EventArgs.Empty);
+        });
     }
 
     private void SetCurrentTheme(AppTheme theme)

--- a/src/WitchDrawer.App/Views/DesktopBoxWindow.xaml
+++ b/src/WitchDrawer.App/Views/DesktopBoxWindow.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:WitchDrawer.App.Controls"
+        xmlns:vm="clr-namespace:WitchDrawer.App.ViewModels"
         Title="{Binding Name}"
         Icon="/Assets/app.png"
         SizeToContent="WidthAndHeight"
@@ -155,8 +156,7 @@
             </Setter>
         </Style>
 
-        <Style x:Key="DrawerTileButtonStyle" TargetType="{x:Type Button}">
-            <Setter Property="MinWidth" Value="0" />
+        <Style x:Key="DrawerTileButtonStyle" TargetType="{x:Type Button}">            <Setter Property="MinWidth" Value="0" />
             <Setter Property="MinHeight" Value="0" />
             <Setter Property="Padding" Value="0" />
             <Setter Property="Margin"
@@ -192,6 +192,72 @@
                 </Setter.Value>
             </Setter>
         </Style>
+
+    <!-- 图标右键菜单：DataContext 是 DrawerItemViewModel（通过 PlacementTarget 解析），
+         命令来自其 Owner（DesktopBoxViewModel）。 -->
+    <ContextMenu x:Key="ItemContextMenu"
+                 DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}"
+                 Background="{DynamicResource PanelBrush}"
+                 BorderBrush="{DynamicResource BorderBrushSoft}"
+                 BorderThickness="1"
+                 Padding="4"
+                 FontSize="12.5">
+        <MenuItem Header="打开"
+                  Command="{Binding Owner.OpenItemCommand}"
+                  CommandParameter="{Binding}" />
+        <MenuItem Header="以管理员身份打开"
+                  Command="{Binding Owner.OpenItemAsAdminCommand}"
+                  CommandParameter="{Binding}"
+                  Visibility="{Binding IsFile, Converter={StaticResource BooleanToVisibilityConverter}}" />
+        <MenuItem Header="打开文件所在位置"
+                  Command="{Binding Owner.ShowItemInFolderCommand}"
+                  CommandParameter="{Binding}" />
+        <MenuItem Header="重命名"
+                  Click="OnRenameItemMenuClicked" />
+        <Separator />
+        <MenuItem Header="排序">
+            <MenuItem Header="按名称"
+                      Command="{Binding Owner.SortItemsCommand}"
+                      CommandParameter="{x:Static vm:DrawerItemSortMode.Name}" />
+            <MenuItem Header="按大小"
+                      Command="{Binding Owner.SortItemsCommand}"
+                      CommandParameter="{x:Static vm:DrawerItemSortMode.Size}" />
+            <MenuItem Header="按类型"
+                      Command="{Binding Owner.SortItemsCommand}"
+                      CommandParameter="{x:Static vm:DrawerItemSortMode.ItemType}" />
+            <MenuItem Header="按修改日期"
+                      Command="{Binding Owner.SortItemsCommand}"
+                      CommandParameter="{x:Static vm:DrawerItemSortMode.ModifiedDate}" />
+        </MenuItem>
+        <MenuItem Header="布局">
+            <MenuItem Header="3×3（超大图标）"
+                      Command="{Binding Owner.LayoutSettings.ApplyPresetCommand}"
+                      CommandParameter="3x3" />
+            <MenuItem Header="4×4（大图标）"
+                      Command="{Binding Owner.LayoutSettings.ApplyPresetCommand}"
+                      CommandParameter="4x4" />
+            <MenuItem Header="5×5（中图标）"
+                      Command="{Binding Owner.LayoutSettings.ApplyPresetCommand}"
+                      CommandParameter="5x5" />
+            <MenuItem Header="6×6（小图标）"
+                      Command="{Binding Owner.LayoutSettings.ApplyPresetCommand}"
+                      CommandParameter="6x6" />
+            <Separator />
+            <MenuItem Header="单排显示（1 行）"
+                      Click="OnSingleRowLayoutMenuClicked" />
+            <MenuItem Header="三行以内（超出滚动）"
+                      Click="OnThreeRowLayoutMenuClicked" />
+            <MenuItem Header="行数不限制（自动增高）"
+                      Click="OnAutoRowLayoutMenuClicked" />
+        </MenuItem>
+        <Separator />
+        <MenuItem Header="移出到桌面"
+                  Command="{Binding Owner.ExportItemToDesktopCommand}"
+                  CommandParameter="{Binding}" />
+        <MenuItem Header="删除"
+                  Command="{Binding Owner.DeleteItemCommand}"
+                  CommandParameter="{Binding}" />
+    </ContextMenu>
     </Window.Resources>
 
     <Border x:Name="WindowBorder">
@@ -443,6 +509,7 @@
                      FocusVisualStyle="{x:Null}"
                      ItemsSource="{Binding Items}"
                      SelectionMode="Single"
+                     MaxHeight="{Binding MaxGridCanvasHeight}"
                      ScrollViewer.CanContentScroll="False"
                      ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                      ScrollViewer.VerticalScrollBarVisibility="Auto"
@@ -455,6 +522,7 @@
                 <ListBox.Style>
                     <Style TargetType="{x:Type ListBox}" BasedOn="{StaticResource {x:Type ListBox}}">
                         <Setter Property="Visibility" Value="Visible" />
+                        <Setter Property="MaxHeight" Value="{Binding MaxGridCanvasHeight}" />
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding IsMappingListMode}" Value="True">
                                 <Setter Property="Visibility" Value="Collapsed" />
@@ -589,7 +657,8 @@
                 </ListBox.ItemContainerStyle>
                 <ListBox.ItemTemplate>
                     <DataTemplate>
-                        <Grid ToolTip="{Binding PathLabel}">
+                        <Grid ToolTip="{Binding PathLabel}"
+                              ContextMenu="{StaticResource ItemContextMenu}">
                             <!-- 图标卡片背景 -->
                             <Border x:Name="IconBorder"
                                     Width="{Binding DataContext.LayoutSettings.IconFrameSize, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}"
@@ -598,7 +667,8 @@
                                     Background="{DynamicResource GlassInnerBrush}"
                                     BorderBrush="{DynamicResource GlassStrokeBrush}"
                                     BorderThickness="1"
-                                    HorizontalAlignment="Center">
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center">
                                 <Grid>
                                     <Image x:Name="IconImage"
                                            Width="{Binding DataContext.LayoutSettings.IconSize, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}"
@@ -621,6 +691,19 @@
                                                Visibility="{Binding HasIcon, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
                                 </Grid>
                             </Border>
+
+                            <!-- 图标下方文件名（可隐藏） -->
+                            <TextBlock Text="{Binding DisplayName}"
+                                       HorizontalAlignment="Center"
+                                       VerticalAlignment="Bottom"
+                                       Margin="0,0,0,-1"
+                                       MaxWidth="{Binding DataContext.LayoutSettings.IconFrameSize, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}"
+                                       FontSize="{Binding DataContext.LayoutSettings.IconFontSize, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}"
+                                       Foreground="{DynamicResource TextMutedBrush}"
+                                       TextTrimming="CharacterEllipsis"
+                                       TextWrapping="{Binding DataContext.LayoutSettings.IconTextWrapping, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}"
+                                       MaxHeight="{Binding DataContext.LayoutSettings.IconTextMaxHeight, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}"
+                                       Visibility="{Binding DataContext.IsItemNameVisible, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         </Grid>
                         <DataTemplate.Triggers>
                             <DataTrigger Binding="{Binding DataContext.IsPixelStyle, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}" Value="True">
@@ -701,7 +784,8 @@
                 </ListBox.ItemContainerStyle>
                 <ListBox.ItemTemplate>
                     <DataTemplate>
-                        <Grid ToolTip="{Binding PathLabel}">
+                        <Grid ToolTip="{Binding PathLabel}"
+                              ContextMenu="{StaticResource ItemContextMenu}">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="{Binding DataContext.LayoutSettings.MappingListIconColumnWidth, RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}" />
                                 <ColumnDefinition Width="*" />
@@ -1335,6 +1419,56 @@
                     </StackPanel>
                 </Grid>
             </Border>
+
+            <!-- 图标重命名输入浮窗 -->
+            <Popup x:Name="RenameItemPopup"
+                   StaysOpen="False"
+                   AllowsTransparency="True"
+                   Placement="Center"
+                   PlacementTarget="{Binding ElementName=WindowBorder}"
+                   PopupAnimation="Fade">
+                <Border Background="{DynamicResource PanelBrush}"
+                        BorderBrush="{DynamicResource BorderBrushSoft}"
+                        BorderThickness="1"
+                        CornerRadius="10"
+                        Padding="12"
+                        Margin="20">
+                    <Border.Effect>
+                        <DropShadowEffect BlurRadius="16" ShadowDepth="4" Opacity="0.15" Direction="270" />
+                    </Border.Effect>
+                    <StackPanel>
+                        <TextBlock Text="重命名图标"
+                                   FontWeight="SemiBold"
+                                   FontSize="12.5"
+                                   Foreground="{DynamicResource TextPrimaryBrush}"
+                                   Margin="0,0,0,8" />
+                        <StackPanel Orientation="Horizontal">
+                            <TextBox x:Name="TxtRenameItem"
+                                     Width="180"
+                                     Height="30"
+                                     VerticalContentAlignment="Center"
+                                     Foreground="{DynamicResource TextPrimaryBrush}"
+                                     Background="{DynamicResource PanelBrush}"
+                                     BorderBrush="{DynamicResource BorderBrushSoft}"
+                                     BorderThickness="1"
+                                     Padding="8,0"
+                                     KeyDown="OnRenameItemKeyDown" />
+                            <Button Content="确认"
+                                    Click="OnConfirmRenameItemClicked"
+                                    Style="{StaticResource {x:Type Button}}"
+                                    Margin="8,0,0,0"
+                                    Padding="16,0"
+                                    Height="30" />
+                        </StackPanel>
+                        <TextBlock Text="仅更改收纳盒内的显示名称，不会修改原文件。"
+                                   FontSize="10.5"
+                                   Foreground="{DynamicResource TextMutedBrush}"
+                                   Margin="0,6,0,0"
+                                   TextWrapping="Wrap"
+                                   MaxWidth="260" />
+                    </StackPanel>
+                </Border>
+            </Popup>
         </Grid>
     </Border>
 </Window>

--- a/src/WitchDrawer.App/Views/DesktopBoxWindow.xaml.cs
+++ b/src/WitchDrawer.App/Views/DesktopBoxWindow.xaml.cs
@@ -37,6 +37,7 @@ public partial class DesktopBoxWindow : Window
     private NativePoint _drawerResizeStartCursor;
     private bool _suppressDrawerItemClick;
     private bool _drawerPositionChanged;
+    private DrawerItemViewModel? _renameTargetItem;
 
     private sealed class DesktopBoxDragPayload(Guid dragId, Guid itemId, Guid sourceBoxId)
     {
@@ -72,6 +73,7 @@ public partial class DesktopBoxWindow : Window
         DpiChanged += OnDpiChanged;
         AppThemeManager.ThemeChanged += OnThemeChanged;
         AppThemeManager.CrystalBoxTransparencyChanged += OnCrystalBoxTransparencyChanged;
+        AppThemeManager.BoxBackgroundOpacityChanged += OnBoxBackgroundOpacityChanged;
         Activated += OnWindowActivated;
         Deactivated += OnWindowDeactivated;
         StateChanged += OnWindowStateChanged;
@@ -395,6 +397,79 @@ public partial class DesktopBoxWindow : Window
         }
     }
 
+    private void OnRenameItemMenuClicked(object sender, RoutedEventArgs e)
+    {
+        if (sender is MenuItem { DataContext: DrawerItemViewModel item })
+        {
+            OpenRenameItemPopup(item);
+        }
+    }
+
+    private void OpenRenameItemPopup(DrawerItemViewModel item)
+    {
+        _renameTargetItem = item;
+        TxtRenameItem.Text = item.DisplayName;
+        RenameItemPopup.IsOpen = true;
+        TxtRenameItem.Focus();
+        TxtRenameItem.SelectAll();
+    }
+
+    private void OnRenameItemKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter)
+        {
+            _ = ConfirmRenameItemAsync();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Escape)
+        {
+            RenameItemPopup.IsOpen = false;
+            e.Handled = true;
+        }
+    }
+
+    private async void OnConfirmRenameItemClicked(object sender, RoutedEventArgs e)
+    {
+        await ConfirmRenameItemAsync();
+    }
+
+    private async Task ConfirmRenameItemAsync()
+    {
+        var item = _renameTargetItem;
+        if (item is null)
+        {
+            RenameItemPopup.IsOpen = false;
+            return;
+        }
+
+        var renamed = await ViewModel.RenameItemAsync(item, TxtRenameItem.Text);
+        if (renamed)
+        {
+            RenameItemPopup.IsOpen = false;
+        }
+    }
+
+    private async void OnSingleRowLayoutMenuClicked(object sender, RoutedEventArgs e)
+    {
+        await ApplyMaxRowsAsync(1);
+    }
+
+    private async void OnThreeRowLayoutMenuClicked(object sender, RoutedEventArgs e)
+    {
+        await ApplyMaxRowsAsync(3);
+    }
+
+    private async void OnAutoRowLayoutMenuClicked(object sender, RoutedEventArgs e)
+    {
+        await ApplyMaxRowsAsync(null);
+    }
+
+    private async Task ApplyMaxRowsAsync(int? maxRows)
+    {
+        ViewModel.ApplyMaxRows(maxRows);
+        await ViewModel.SaveMaxRowsAsync(maxRows);
+    }
+
     private static T? FindVisualAncestor<T>(DependencyObject source)
         where T : DependencyObject
     {
@@ -436,6 +511,7 @@ public partial class DesktopBoxWindow : Window
         DpiChanged -= OnDpiChanged;
         AppThemeManager.ThemeChanged -= OnThemeChanged;
         AppThemeManager.CrystalBoxTransparencyChanged -= OnCrystalBoxTransparencyChanged;
+        AppThemeManager.BoxBackgroundOpacityChanged -= OnBoxBackgroundOpacityChanged;
         Activated -= OnWindowActivated;
         Deactivated -= OnWindowDeactivated;
         StateChanged -= OnWindowStateChanged;
@@ -551,10 +627,56 @@ public partial class DesktopBoxWindow : Window
         ApplyThemeAppearance();
     }
 
+    private void OnBoxBackgroundOpacityChanged(object? sender, double opacity)
+    {
+        ApplyThemeAppearance();
+    }
+
     private void ApplyThemeAppearance()
     {
         AppThemeManager.ApplyDesktopBoxResources(Resources);
         AppThemeManager.ApplyToWindow(this);
+        ApplyBoxBackgroundOpacity();
+    }
+
+    private static readonly string[] GlassBrushKeys =
+    [
+        "GlassSurfaceBrush",
+        "GlassStrokeBrush",
+        "GlassInnerBrush",
+        "DrawerSecondarySurfaceBrush"
+    ];
+
+    /// <summary>
+    /// Scales the alpha of the four glass brushes used by desktop boxes so the
+    /// box background can fade independently of its icon/text content.
+    /// </summary>
+    private void ApplyBoxBackgroundOpacity()
+    {
+        var opacity = AppThemeManager.BoxBackgroundOpacity;
+        // Icon backplates stay at least 30% of their authored alpha so icons
+        // remain readable even at the most transparent setting.
+        var innerOpacity = Math.Max(0.3, opacity);
+
+        foreach (var key in GlassBrushKeys)
+        {
+            // 透明水晶模式会把透明版颜色注入窗口 Resources；必须先以窗口级
+            // 颜色为基准，Remove 后再回退到 Application 全局主题色。
+            var themeBrush = Resources[key] as SolidColorBrush
+                ?? Application.Current.TryFindResource(key) as SolidColorBrush;
+            if (themeBrush is null)
+            {
+                continue;
+            }
+
+            Resources.Remove(key);
+            var multiplier = key == "GlassInnerBrush" ? innerOpacity : opacity;
+            var color = themeBrush.Color;
+            color.A = (byte)Math.Round(color.A * multiplier);
+            var brush = new SolidColorBrush(color);
+            brush.Freeze();
+            Resources[key] = brush;
+        }
     }
 
     private void OnWindowActivated(object? sender, EventArgs e)

--- a/src/WitchDrawer.Core/Abstractions/IFileLauncher.cs
+++ b/src/WitchDrawer.Core/Abstractions/IFileLauncher.cs
@@ -3,5 +3,14 @@ namespace WitchDrawer.Core.Abstractions;
 public interface IFileLauncher
 {
     Task OpenAsync(string path, CancellationToken cancellationToken = default);
-}
 
+    /// <summary>
+    /// Opens the file with elevation (the shell "runas" verb).
+    /// </summary>
+    Task OpenAsAdminAsync(string path, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Opens the containing folder in Explorer with the item selected.
+    /// </summary>
+    Task ShowInFolderAsync(string path, CancellationToken cancellationToken = default);
+}

--- a/src/WitchDrawer.Core/Services/ClassifyCategory.cs
+++ b/src/WitchDrawer.Core/Services/ClassifyCategory.cs
@@ -1,0 +1,88 @@
+namespace WitchDrawer.Core.Services;
+
+/// <summary>
+/// Groups drawer item names/paths into display categories used by the
+/// one-click classification feature. Each category owns a mapping-box name.
+/// </summary>
+public static class ClassifyCategory
+{
+    public sealed record Category(string BoxName, string DisplayName);
+
+    public static Category GetCategory(string? displayName, string? sourcePath, bool isDirectory = false)
+    {
+        var extension = GetExtension(displayName, sourcePath);
+
+        if (ImageExtensions.Contains(extension))
+        {
+            return new Category("图片收纳盒", "图片");
+        }
+
+        if (DocumentExtensions.Contains(extension))
+        {
+            return new Category("文档收纳盒", "文档");
+        }
+
+        if (VideoExtensions.Contains(extension))
+        {
+            return new Category("视频收纳盒", "视频");
+        }
+
+        if (AudioExtensions.Contains(extension))
+        {
+            return new Category("音频收纳盒", "音频");
+        }
+
+        if (ArchiveExtensions.Contains(extension))
+        {
+            return new Category("压缩包收纳盒", "压缩包");
+        }
+
+        if (isDirectory)
+        {
+            return new Category("文件夹收纳盒", "文件夹");
+        }
+
+        return new Category("其他收纳盒", "其他");
+    }
+
+    private static string GetExtension(string? displayName, string? sourcePath)
+    {
+        var name = displayName;
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            name = sourcePath;
+        }
+
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return string.Empty;
+        }
+
+        return Path.GetExtension(name).TrimStart('.').ToLowerInvariant();
+    }
+
+    private static readonly HashSet<string> ImageExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "png", "jpg", "jpeg", "gif", "bmp", "webp", "ico", "svg", "tif", "tiff", "heic", "avif", "jfif"
+    };
+
+    private static readonly HashSet<string> DocumentExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "doc", "docx", "pdf", "txt", "md", "xls", "xlsx", "ppt", "pptx", "csv", "rtf", "odt", "ods", "odp", "wps", "et", "dps", "pages", "numbers", "key"
+    };
+
+    private static readonly HashSet<string> VideoExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "mp4", "mkv", "avi", "mov", "wmv", "flv", "webm", "m4v", "mpg", "mpeg", "ts", "rmvb", "rm", "3gp"
+    };
+
+    private static readonly HashSet<string> AudioExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "mp3", "wav", "flac", "aac", "ogg", "m4a", "wma", "opus", "ape", "amr"
+    };
+
+    private static readonly HashSet<string> ArchiveExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "zip", "rar", "7z", "tar", "gz", "bz2", "xz", "zst", "iso", "cab", "lz4"
+    };
+}

--- a/src/WitchDrawer.Core/Services/ClassifyResult.cs
+++ b/src/WitchDrawer.Core/Services/ClassifyResult.cs
@@ -1,0 +1,6 @@
+namespace WitchDrawer.Core.Services;
+
+/// <summary>
+/// Result of a one-click classification pass.
+/// </summary>
+public sealed record ClassifyResult(int MovedCount, int SkippedCount);

--- a/src/WitchDrawer.Core/Services/DrawerService.cs
+++ b/src/WitchDrawer.Core/Services/DrawerService.cs
@@ -631,6 +631,221 @@ public sealed class DrawerService
         await _repository.UpdateBoxNameAsync(boxId, newName.Trim(), cancellationToken);
     }
 
+    /// <summary>
+    /// Renames the drawer item's display name only. The underlying file on disk
+    /// keeps its real name, so this never mutates the user's file system entry.
+    /// A trailing ".lnk" is re-appended when the stored name used it, keeping the
+    /// shortcut look consistent for mapping boxes.
+    /// </summary>
+    public async Task RenameItemAsync(
+        Guid itemId,
+        string newDisplayName,
+        CancellationToken cancellationToken = default)
+    {
+        var normalizedName = newDisplayName?.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedName))
+        {
+            throw new ArgumentException("Item name cannot be empty.", nameof(newDisplayName));
+        }
+
+        var item = await _repository.GetItemAsync(itemId, cancellationToken)
+            ?? throw new InvalidOperationException("Item does not exist.");
+
+        var storedName = item.DisplayName;
+        var storeWithLinkSuffix = storedName.EndsWith(".lnk", StringComparison.OrdinalIgnoreCase);
+        if (storeWithLinkSuffix
+            && !normalizedName.EndsWith(".lnk", StringComparison.OrdinalIgnoreCase))
+        {
+            normalizedName += ".lnk";
+        }
+
+        await _repository.UpdateItemDisplayNameAsync(itemId, normalizedName, cancellationToken);
+    }
+
+    public async Task OpenItemAsAdminAsync(
+        Guid itemId,
+        IFileLauncher launcher,
+        CancellationToken cancellationToken = default)
+    {
+        var item = await _repository.GetItemAsync(itemId, cancellationToken)
+            ?? throw new InvalidOperationException("Item does not exist.");
+
+        if (item.ItemKind == ItemKind.Directory)
+        {
+            throw new InvalidOperationException("Folders cannot be opened with administrator rights.");
+        }
+
+        var path = item.EffectivePath;
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new InvalidOperationException("Item has no file path.");
+        }
+
+        await launcher.OpenAsAdminAsync(path, cancellationToken);
+    }
+
+    public async Task ShowItemInFolderAsync(
+        Guid itemId,
+        IFileLauncher launcher,
+        CancellationToken cancellationToken = default)
+    {
+        var item = await _repository.GetItemAsync(itemId, cancellationToken)
+            ?? throw new InvalidOperationException("Item does not exist.");
+
+        var path = item.EffectivePath;
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new InvalidOperationException("Item has no file path.");
+        }
+
+        await launcher.ShowInFolderAsync(path, cancellationToken);
+    }
+
+    /// <summary>
+    /// Merges every item of <paramref name="sourceBoxId"/> into
+    /// <paramref name="targetBoxId"/> and then deletes the source box.
+    /// Stored items are physically moved into the target box storage;
+    /// mapping references are re-pointed at the target box.
+    /// </summary>
+    /// <returns>The number of items merged.</returns>
+    public async Task<int> MergeBoxAsync(
+        Guid sourceBoxId,
+        Guid targetBoxId,
+        CancellationToken cancellationToken = default)
+    {
+        if (sourceBoxId == targetBoxId)
+        {
+            throw new InvalidOperationException("Cannot merge a box into itself.");
+        }
+
+        var sourceBox = await _repository.GetBoxAsync(sourceBoxId, cancellationToken)
+            ?? throw new InvalidOperationException("Source box does not exist.");
+        var targetBox = await _repository.GetBoxAsync(targetBoxId, cancellationToken)
+            ?? throw new InvalidOperationException("Target box does not exist.");
+
+        if (sourceBox.Type == BoxType.Todo || targetBox.Type == BoxType.Todo)
+        {
+            throw new InvalidOperationException("Todo boxes cannot be merged.");
+        }
+
+        var sourceIsMapping = sourceBox.Type == BoxType.Mapping;
+        var targetIsMapping = targetBox.Type == BoxType.Mapping;
+        if (sourceIsMapping != targetIsMapping)
+        {
+            throw new InvalidOperationException(
+                "Mapping boxes can only be merged into other mapping boxes, "
+                + "and storage boxes only into other storage boxes.");
+        }
+
+        var items = await _repository.GetItemsAsync(sourceBoxId, cancellationToken);
+
+        // 预检：映射盒的每一项都必须是无存储路径的引用，存储盒的每一项都必须
+        // 有可移动的存储文件，避免中途失败后才暴露数据异常。
+        foreach (var item in items)
+        {
+            if (sourceIsMapping && !string.IsNullOrWhiteSpace(item.StoredPath))
+            {
+                throw new InvalidOperationException(
+                    $"“{item.DisplayName}”是存储项，不能并入映射盒。");
+            }
+
+            if (!sourceIsMapping && string.IsNullOrWhiteSpace(item.StoredPath))
+            {
+                throw new InvalidOperationException(
+                    $"“{item.DisplayName}”没有可移动的存储文件。");
+            }
+        }
+
+        var movedItems = new List<DrawerItem>(items.Count);
+        try
+        {
+            foreach (var item in items)
+            {
+                await MoveItemToBoxAsync(item.Id, targetBoxId, cancellationToken: cancellationToken);
+                movedItems.Add(item);
+            }
+        }
+        catch (Exception exception)
+        {
+            // Best-effort rollback: move already-merged items back to the source
+            // box so a failed merge does not leave a half-migrated state.
+            foreach (var item in movedItems)
+            {
+                try
+                {
+                    await MoveItemToBoxAsync(item.Id, sourceBoxId, cancellationToken: cancellationToken);
+                }
+                catch
+                {
+                    // Rollback is best-effort; the original failure is rethrown.
+                }
+            }
+
+            throw new InvalidOperationException(
+                $"合并中断（已移动 {movedItems.Count}/{items.Count} 项，尝试回滚）：{exception.Message}",
+                exception);
+        }
+
+        var deleteResult = await DeleteBoxAsync(sourceBoxId, cancellationToken);
+        if (!deleteResult.BoxRemoved)
+        {
+            throw new InvalidOperationException(
+                "Items were merged but the source box could not be removed: "
+                + string.Join("; ", deleteResult.Failures));
+        }
+
+        return items.Count;
+    }
+
+    /// <summary>
+    /// One-click classification: moves every mapping reference (items that point
+    /// at external files) into per-type mapping boxes ("图片收纳盒", "文档收纳盒",
+    /// ...). Stored items are intentionally left untouched because they must not
+    /// be moved into mapping boxes.
+    /// </summary>
+    public async Task<ClassifyResult> ClassifyMappingItemsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var boxes = await _repository.GetBoxesAsync(cancellationToken);
+        var allItems = await _repository.GetItemsAsync(null, cancellationToken);
+
+        var targetBoxes = new Dictionary<string, Box>(StringComparer.OrdinalIgnoreCase);
+        var movedCount = 0;
+        var skippedCount = 0;
+
+        foreach (var item in allItems)
+        {
+            if (!string.IsNullOrWhiteSpace(item.StoredPath))
+            {
+                skippedCount++;
+                continue;
+            }
+
+            var category = ClassifyCategory.GetCategory(
+                item.DisplayName,
+                item.SourcePath,
+                isDirectory: item.ItemKind == ItemKind.Directory);
+            if (!targetBoxes.TryGetValue(category.BoxName, out var targetBox))
+            {
+                targetBox = boxes.FirstOrDefault(box => box.Type == BoxType.Mapping
+                    && string.Equals(box.Name, category.BoxName, StringComparison.OrdinalIgnoreCase))
+                    ?? await CreateBoxAsync(category.BoxName, BoxType.Mapping, cancellationToken);
+                targetBoxes[category.BoxName] = targetBox;
+            }
+
+            if (item.BoxId == targetBox.Id)
+            {
+                skippedCount++;
+                continue;
+            }
+
+            await MoveItemToBoxAsync(item.Id, targetBox.Id, cancellationToken: cancellationToken);
+            movedCount++;
+        }
+
+        return new ClassifyResult(movedCount, skippedCount);
+    }
+
     public async Task OpenItemAsync(Guid itemId, IFileLauncher launcher, CancellationToken cancellationToken = default)
     {
         var item = await _repository.GetItemAsync(itemId, cancellationToken)

--- a/src/WitchDrawer.Core/Services/DrawerService.cs
+++ b/src/WitchDrawer.Core/Services/DrawerService.cs
@@ -144,7 +144,20 @@ public sealed class DrawerService
             var targetPath = FileNameService.GetUniqueDestinationPath(storageRoot, displayName, isDirectory);
             PathSafety.EnsureChildPath(storageRoot, targetPath);
 
-            await SafeFileOps.MoveAsync(fullSourcePath, targetPath, isDirectory, cancellationToken);
+            try
+            {
+                await SafeFileOps.MoveAsync(fullSourcePath, targetPath, isDirectory, cancellationToken);
+            }
+            catch (UnauthorizedAccessException exception)
+            {
+                throw CreateImportPermissionException(displayName, fullSourcePath, exception);
+            }
+            catch (IOException exception)
+            {
+                throw new InvalidOperationException(
+                    $"无法收纳“{displayName}”：{exception.Message}",
+                    exception);
+            }
 
             item = new DrawerItem(
                 Guid.NewGuid(),
@@ -249,7 +262,20 @@ public sealed class DrawerService
             var targetPath = FileNameService.GetUniqueDestinationPath(storageRoot, displayName, isDirectory);
             PathSafety.EnsureChildPath(storageRoot, targetPath);
 
-            await SafeFileOps.MoveAsync(fullSourcePath, targetPath, isDirectory, cancellationToken);
+            try
+            {
+                await SafeFileOps.MoveAsync(fullSourcePath, targetPath, isDirectory, cancellationToken);
+            }
+            catch (UnauthorizedAccessException exception)
+            {
+                throw CreateImportPermissionException(displayName, fullSourcePath, exception);
+            }
+            catch (IOException exception)
+            {
+                throw new InvalidOperationException(
+                    $"无法移动“{displayName}”：{exception.Message}",
+                    exception);
+            }
 
             displayName = Path.GetFileName(targetPath);
             storedPath = targetPath;
@@ -545,6 +571,31 @@ public sealed class DrawerService
         }
 
         return Path.GetFullPath(desktopPath);
+    }
+
+    /// <summary>
+    /// Wraps a file-move permission failure with an actionable hint. The most
+    /// common cause is dragging from a read-only system location such as the
+    /// public desktop (C:\Users\Public\Desktop), where the source directory is
+    /// not writable and the file cannot be deleted as part of the move.
+    /// </summary>
+    internal static InvalidOperationException CreateImportPermissionException(
+        string displayName,
+        string sourcePath,
+        UnauthorizedAccessException innerException)
+    {
+        var commonDesktop = Environment.GetFolderPath(
+            Environment.SpecialFolder.CommonDesktopDirectory);
+        var isPublicDesktop = !string.IsNullOrWhiteSpace(commonDesktop)
+            && sourcePath.StartsWith(commonDesktop, StringComparison.OrdinalIgnoreCase);
+        var hint = isPublicDesktop
+            ? "源位置（公共桌面）默认只读，无法从中移走文件。"
+            : "源目录没有写入权限，无法移走文件。";
+        return new InvalidOperationException(
+            $"无法收纳“{displayName}”：{hint}"
+            + "可改用“映射收纳盒”（仅保存引用、不移动文件），"
+            + "或先将文件复制到可写位置再拖入。",
+            innerException);
     }
 
     private static string GetReservedUniqueDestinationPath(

--- a/src/WitchDrawer.Core/Storage/DrawerRepository.cs
+++ b/src/WitchDrawer.Core/Storage/DrawerRepository.cs
@@ -376,6 +376,34 @@ public sealed class DrawerRepository
         await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
+    /// <summary>
+    /// Updates only the display name of an item. The underlying file (if any)
+    /// keeps its on-disk name, so renaming inside a drawer never touches the
+    /// original file system entry.
+    /// </summary>
+    public async Task UpdateItemDisplayNameAsync(
+        Guid itemId,
+        string newDisplayName,
+        CancellationToken cancellationToken = default)
+    {
+        await using var connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+
+        var command = connection.CreateCommand();
+        command.CommandText =
+            """
+            UPDATE Items
+            SET DisplayName = $displayName,
+                UpdatedAt = $updatedAt
+            WHERE Id = $id;
+            """;
+        command.Parameters.AddWithValue("$id", itemId.ToString());
+        command.Parameters.AddWithValue("$displayName", newDisplayName);
+        command.Parameters.AddWithValue("$updatedAt", ToDb(DateTimeOffset.UtcNow));
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
     public async Task MoveItemToBoxAsync(
         DrawerItem item,
         Guid targetBoxId,

--- a/src/WitchDrawer.Native/Files/ShellFileLauncher.cs
+++ b/src/WitchDrawer.Native/Files/ShellFileLauncher.cs
@@ -22,5 +22,44 @@ public sealed class ShellFileLauncher : IFileLauncher
 
         return Task.CompletedTask;
     }
-}
 
+    public Task OpenAsAdminAsync(string path, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!File.Exists(path) && !Directory.Exists(path))
+        {
+            throw new FileNotFoundException("Cannot open a missing file or directory.", path);
+        }
+
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = path,
+            UseShellExecute = true,
+            Verb = "runas"
+        });
+
+        return Task.CompletedTask;
+    }
+
+    public Task ShowInFolderAsync(string path, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!File.Exists(path) && !Directory.Exists(path))
+        {
+            throw new FileNotFoundException("Cannot reveal a missing file or directory.", path);
+        }
+
+        // explorer.exe /select,"<path>" opens the containing folder and highlights
+        // the item without navigating the folder first.
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = "explorer.exe",
+            Arguments = $"/select,\"{path}\"",
+            UseShellExecute = true
+        });
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/WitchDrawer.App.Tests/AppThemeManagerTests.cs
+++ b/tests/WitchDrawer.App.Tests/AppThemeManagerTests.cs
@@ -26,4 +26,29 @@ public sealed class AppThemeManagerTests
             AppThemeManager.SetCrystalBoxTransparency(false);
         }
     }
+
+    [Fact]
+    public void SetBoxBackgroundOpacity_ClampsAndRaisesEventOnlyWhenValueChanges()
+    {
+        AppThemeManager.SetBoxBackgroundOpacity(1.0);
+        var changes = new List<double>();
+        EventHandler<double> handler = (_, opacity) => changes.Add(opacity);
+        AppThemeManager.BoxBackgroundOpacityChanged += handler;
+
+        try
+        {
+            AppThemeManager.SetBoxBackgroundOpacity(0.6);
+            AppThemeManager.SetBoxBackgroundOpacity(0.6);
+            AppThemeManager.SetBoxBackgroundOpacity(0.0); // 低于下限 → clamp 到 0.05
+            AppThemeManager.SetBoxBackgroundOpacity(3.0); // 高于上限 → clamp 到 1.0
+
+            Assert.Equal(1.0, AppThemeManager.BoxBackgroundOpacity, precision: 10);
+            Assert.Equal([0.6, 0.05, 1.0], changes);
+        }
+        finally
+        {
+            AppThemeManager.BoxBackgroundOpacityChanged -= handler;
+            AppThemeManager.SetBoxBackgroundOpacity(1.0);
+        }
+    }
 }

--- a/tests/WitchDrawer.App.Tests/DesktopBoxViewModelLayoutTests.cs
+++ b/tests/WitchDrawer.App.Tests/DesktopBoxViewModelLayoutTests.cs
@@ -1,0 +1,167 @@
+using System.IO;
+using WitchDrawer.App.Infrastructure;
+using WitchDrawer.App.ViewModels;
+using WitchDrawer.Core;
+using WitchDrawer.Core.Abstractions;
+using WitchDrawer.Core.Logging;
+using WitchDrawer.Core.Models;
+using WitchDrawer.Core.Services;
+using WitchDrawer.Core.Storage;
+
+namespace WitchDrawer.App.Tests;
+
+public sealed class DesktopBoxViewModelLayoutTests
+{
+    [Fact]
+    public async Task ApplyMaxRows_LimitsGridCanvasHeight()
+    {
+        using var workspace = await TestWorkspace.CreateAsync();
+        var box = await workspace.CreateBoxAsync(BoxType.Normal);
+        var viewModel = await workspace.CreateViewModelAsync(box);
+        await viewModel.LoadAsync();
+
+        // 3 列预设：10 项自动放置为 3+3+3+1 = 4 行。
+        viewModel.LayoutSettings.ApplyPresetWithoutCallback("3x3");
+        for (var index = 0; index < 10; index++)
+        {
+            var file = workspace.CreateSourceFile("rows", $"f{index}.txt", "x");
+            await viewModel.ImportPathsAsync([file]);
+        }
+
+        var slotHeight = viewModel.LayoutSettings.ItemSlotHeight;
+        Assert.True(viewModel.GridCanvasHeight > slotHeight * 3, "导入 10 项后画布应超过 3 行高。");
+
+        viewModel.ApplyMaxRows(2);
+
+        Assert.Equal(2, viewModel.MaxRows);
+        Assert.Equal(slotHeight * 2, viewModel.GridCanvasHeight, precision: 5);
+        Assert.Equal(slotHeight * 2, viewModel.MaxGridCanvasHeight, precision: 5);
+
+        viewModel.ApplyMaxRows(null);
+        Assert.Null(viewModel.MaxRows);
+        Assert.True(viewModel.GridCanvasHeight > slotHeight * 3, "取消行数限制后画布恢复完整高度。");
+    }
+
+    [Fact]
+    public async Task ApplyMaxRows_PersistsAndRestores()
+    {
+        using var workspace = await TestWorkspace.CreateAsync();
+        var box = await workspace.CreateBoxAsync(BoxType.Normal);
+        var viewModel = await workspace.CreateViewModelAsync(box);
+
+        await viewModel.SaveMaxRowsAsync(3);
+        await viewModel.LoadMaxRowsAsync();
+
+        Assert.Equal(3, viewModel.MaxRows);
+        Assert.Equal(
+            "3",
+            await workspace.Service.GetSettingAsync(DesktopBoxViewModel.GetMaxRowsSettingKey(box.Id)));
+    }
+
+    [Fact]
+    public async Task ItemNameVisibility_DefaultsVisibleAndPersists()
+    {
+        using var workspace = await TestWorkspace.CreateAsync();
+        var box = await workspace.CreateBoxAsync(BoxType.Normal);
+        var viewModel = await workspace.CreateViewModelAsync(box);
+        await viewModel.LoadItemNameVisibilityAsync();
+
+        Assert.True(viewModel.IsItemNameVisible);
+
+        viewModel.ApplyItemNameVisibility(false);
+        await workspace.Service.SetSettingAsync(
+            DesktopBoxViewModel.GetItemNameVisibilitySettingKey(box.Id),
+            bool.FalseString);
+
+        var reloaded = await workspace.CreateViewModelAsync(box);
+        await reloaded.LoadItemNameVisibilityAsync();
+        Assert.False(reloaded.IsItemNameVisible);
+    }
+
+    private sealed class TestWorkspace : IDisposable
+    {
+        private TestWorkspace(string root, AppPaths paths, DrawerService service)
+        {
+            Root = root;
+            Paths = paths;
+            Service = service;
+        }
+
+        public string Root { get; }
+
+        public AppPaths Paths { get; }
+
+        public DrawerService Service { get; }
+
+        public static async Task<TestWorkspace> CreateAsync()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "WitchDrawerTests", Guid.NewGuid().ToString("N"));
+            var paths = new AppPaths(root);
+            var repository = new DrawerRepository(paths.DatabasePath);
+            var service = new DrawerService(paths, repository);
+            await service.InitializeAsync();
+            return new TestWorkspace(root, paths, service);
+        }
+
+        public async Task<Box> CreateBoxAsync(BoxType type)
+        {
+            return await Service.CreateBoxAsync($"box-{Guid.NewGuid():N}"[..8], type);
+        }
+
+        public string CreateSourceFile(string folderName, string fileName, string content)
+        {
+            var directory = Path.Combine(Root, "sources", folderName);
+            Directory.CreateDirectory(directory);
+            var path = Path.Combine(directory, fileName);
+            File.WriteAllText(path, content);
+            return path;
+        }
+
+        public async Task<DesktopBoxViewModel> CreateViewModelAsync(Box box)
+        {
+            var repository = new DrawerRepository(Paths.DatabasePath);
+            return new DesktopBoxViewModel(
+                box,
+                Service,
+                new TodoService(repository),
+                new NoOpFileLauncher(),
+                new RecordingLogger(),
+                BoxVisualStyle.Modern);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(Root))
+                {
+                    Directory.Delete(Root, recursive: true);
+                }
+            }
+            catch
+            {
+                // Best-effort test cleanup.
+            }
+        }
+    }
+
+    private sealed class NoOpFileLauncher : IFileLauncher
+    {
+        public Task OpenAsync(string path, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task OpenAsAdminAsync(string path, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task ShowInFolderAsync(string path, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class RecordingLogger : IAppLogger
+    {
+        public void Info(string message)
+        {
+        }
+
+        public void Error(Exception exception, string message)
+        {
+        }
+    }
+}

--- a/tests/WitchDrawer.App.Tests/DrawerBoxCreationTests.cs
+++ b/tests/WitchDrawer.App.Tests/DrawerBoxCreationTests.cs
@@ -92,6 +92,10 @@ public sealed class DrawerBoxCreationTests
     private sealed class NoOpFileLauncher : IFileLauncher
     {
         public Task OpenAsync(string path, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task OpenAsAdminAsync(string path, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task ShowInFolderAsync(string path, CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 
     private sealed class RecordingLogger : IAppLogger

--- a/tests/WitchDrawer.App.Tests/StyledNormalBoxCreationTests.cs
+++ b/tests/WitchDrawer.App.Tests/StyledNormalBoxCreationTests.cs
@@ -84,6 +84,20 @@ public sealed class StyledNormalBoxCreationTests
         {
             return Task.CompletedTask;
         }
+
+        public Task OpenAsAdminAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task ShowInFolderAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class RecordingLogger : IAppLogger

--- a/tests/WitchDrawer.App.Tests/TodoBoxDetailViewModelTests.cs
+++ b/tests/WitchDrawer.App.Tests/TodoBoxDetailViewModelTests.cs
@@ -224,5 +224,19 @@ public sealed class TodoBoxDetailViewModelTests
         {
             return Task.CompletedTask;
         }
+
+        public Task OpenAsAdminAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task ShowInFolderAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/tests/WitchDrawer.Core.Tests/DrawerServiceAdvancedTests.cs
+++ b/tests/WitchDrawer.Core.Tests/DrawerServiceAdvancedTests.cs
@@ -1,0 +1,370 @@
+using WitchDrawer.Core;
+using WitchDrawer.Core.Abstractions;
+using WitchDrawer.Core.Models;
+using WitchDrawer.Core.Services;
+using WitchDrawer.Core.Storage;
+
+namespace WitchDrawer.Core.Tests;
+
+public sealed class DrawerServiceAdvancedTests
+{
+    [Fact]
+    public async Task RenameItemAsync_ChangesDisplayNameOnly_NotTheFileOnDisk()
+    {
+        using var workspace = await TestWorkspace.CreateAsync();
+        var box = await workspace.GetBoxAsync(BoxType.Mapping);
+        var file = workspace.CreateSourceFile("rename", "old-name.txt", "content");
+        var item = await workspace.Service.ImportPathAsync(box.Id, file);
+
+        await workspace.Service.RenameItemAsync(item.Id, "新显示名");
+
+        var items = await workspace.Service.GetItemsAsync(box.Id);
+        var renamed = Assert.Single(items);
+        Assert.Equal("新显示名", renamed.DisplayName);
+        Assert.True(File.Exists(file), "原文件必须保持原名且不被移动。");
+        Assert.Equal("old-name.txt", Path.GetFileName(file));
+    }
+
+    [Fact]
+    public async Task RenameItemAsync_KeepsLinkSuffixForShortcutNames()
+    {
+        using var workspace = await TestWorkspace.CreateAsync();
+        var box = await workspace.GetBoxAsync(BoxType.Mapping);
+        var file = workspace.CreateSourceFile("rename", "app.lnk", "dummy shortcut");
+        var item = await workspace.Service.ImportPathAsync(box.Id, file);
+
+        await workspace.Service.RenameItemAsync(item.Id, "我的应用");
+
+        var items = await workspace.Service.GetItemsAsync(box.Id);
+        Assert.Equal("我的应用.lnk", Assert.Single(items).DisplayName);
+    }
+
+    [Fact]
+    public async Task RenameItemAsync_RejectsEmptyName()
+    {
+        using var workspace = await TestWorkspace.CreateAsync();
+        var box = await workspace.GetBoxAsync(BoxType.Mapping);
+        var file = workspace.CreateSourceFile("rename", "a.txt", "content");
+        var item = await workspace.Service.ImportPathAsync(box.Id, file);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => workspace.Service.RenameItemAsync(item.Id, "   "));
+    }
+
+    [Fact]
+    public async Task OpenItemAsAdminAsync_LaunchesWithAdminVerbForFiles()
+    {
+        using var workspace = await TestWorkspace.CreateAsync();
+        var box = await workspace.GetBoxAsync(BoxType.Mapping);
+        var file = workspace.CreateSourceFile("launch", "tool.exe", "binary");
+        var item = await workspace.Service.ImportPathAsync(box.Id, file);
+        var launcher = new RecordingFileLauncher();
+
+        await workspace.Service.OpenItemAsAdminAsync(item.Id, launcher);
+
+        Assert.Equal(Path.GetFullPath(file), launcher.AdminOpened.Single());
+    }
+
+    [Fact]
+    public async Task OpenItemAsAdminAsync_RejectsDirectories()
+    {
+        using var workspace = await TestWorkspace.CreateAsync();
+        var box = await workspace.GetBoxAsync(BoxType.Mapping);
+        var directory = workspace.CreateSourceDirectory("launch", "nested.txt", "content");
+        var item = await workspace.Service.ImportPathAsync(box.Id, directory);
+        var launcher = new RecordingFileLauncher();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => workspace.Service.OpenItemAsAdminAsync(item.Id, launcher));
+    }
+
+    [Fact]
+    public async Task ShowItemInFolderAsync_RevealsTheEffectivePath()
+    {
+        using var workspace = await TestWorkspace.CreateAsync();
+        var box = await workspace.GetBoxAsync(BoxType.Mapping);
+        var file = workspace.CreateSourceFile("launch", "doc.pdf", "pdf");
+        var item = await workspace.Service.ImportPathAsync(box.Id, file);
+        var launcher = new RecordingFileLauncher();
+
+        await workspace.Service.ShowItemInFolderAsync(item.Id, launcher);
+
+        Assert.Equal(Path.GetFullPath(file), launcher.Revealed.Single());
+    }
+
+    [Fact]
+    public async Task MergeBoxAsync_MovesStoredFilesAndRemovesSourceBox()
+    {
+        using var workspace = await TestWorkspace.CreateAsync();
+        var sourceBox = await workspace.Service.CreateBoxAsync("来源盒", BoxType.Normal);
+        var targetBox = await workspace.Service.CreateBoxAsync("目标盒", BoxType.Normal);
+        var file = workspace.CreateSourceFile("merge", "a.txt", "hello");
+        var item = await workspace.Service.ImportPathAsync(sourceBox.Id, file);
+        var originalStoredPath = item.StoredPath!;
+        Assert.True(File.Exists(originalStoredPath));
+
+        var mergedCount = await workspace.Service.MergeBoxAsync(sourceBox.Id, targetBox.Id);
+
+        Assert.Equal(1, mergedCount);
+        Assert.DoesNotContain(await workspace.Service.GetBoxesAsync(), box => box.Id == sourceBox.Id);
+        Assert.False(File.Exists(originalStoredPath), "文件应被移出源盒存储目录。");
+
+        var items = await workspace.Service.GetItemsAsync(targetBox.Id);
+        var moved = Assert.Single(items);
+        Assert.Equal(item.Id, moved.Id);
+        Assert.NotNull(moved.StoredPath);
+        Assert.True(File.Exists(moved.StoredPath), "文件应存在于目标盒存储目录。");
+    }
+
+    [Fact]
+    public async Task MergeBoxAsync_RepointsMappingReferencesWithoutTouchingFiles()
+    {
+        using var workspace = await TestWorkspace.CreateAsync();
+        var sourceBox = await workspace.Service.CreateBoxAsync("来源映射盒", BoxType.Mapping);
+        var targetBox = await workspace.Service.CreateBoxAsync("目标映射盒", BoxType.Mapping);
+        var file = workspace.CreateSourceFile("merge-map", "photo.png", "image");
+        var item = await workspace.Service.ImportPathAsync(sourceBox.Id, file);
+        Assert.Null(item.StoredPath);
+
+        var mergedCount = await workspace.Service.MergeBoxAsync(sourceBox.Id, targetBox.Id);
+
+        Assert.Equal(1, mergedCount);
+        Assert.True(File.Exists(file), "映射盒合并不能移动源文件。");
+        var items = await workspace.Service.GetItemsAsync(targetBox.Id);
+        Assert.Equal(item.Id, Assert.Single(items).Id);
+    }
+
+    [Fact]
+    public async Task MergeBoxAsync_RejectsMixingMappingAndStorageBoxes()
+    {
+        using var workspace = await TestWorkspace.CreateAsync();
+        var normalBox = await workspace.Service.CreateBoxAsync("普通盒", BoxType.Normal);
+        var mappingBox = await workspace.Service.CreateBoxAsync("映射盒", BoxType.Mapping);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => workspace.Service.MergeBoxAsync(normalBox.Id, mappingBox.Id));
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => workspace.Service.MergeBoxAsync(mappingBox.Id, normalBox.Id));
+    }
+
+    [Fact]
+    public async Task MergeBoxAsync_RejectsTodoBoxesAndSelfMerge()
+    {
+        using var workspace = await TestWorkspace.CreateAsync();
+        var normalBox = await workspace.Service.CreateBoxAsync("普通盒", BoxType.Normal);
+        var todoBox = await workspace.Service.CreateBoxAsync("待办盒", BoxType.Todo);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => workspace.Service.MergeBoxAsync(normalBox.Id, normalBox.Id));
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => workspace.Service.MergeBoxAsync(normalBox.Id, todoBox.Id));
+    }
+
+    [Fact]
+    public async Task ClassifyMappingItemsAsync_GroupsReferencesIntoTypeBoxes()
+    {
+        using var workspace = await TestWorkspace.CreateAsync();
+        var mappingBox = await workspace.GetBoxAsync(BoxType.Mapping);
+        var photo = workspace.CreateSourceFile("classify", "photo.png", "image");
+        var doc = workspace.CreateSourceFile("classify", "readme.md", "markdown");
+        var video = workspace.CreateSourceFile("classify", "clip.mp4", "video");
+        await workspace.Service.ImportPathAsync(mappingBox.Id, photo);
+        await workspace.Service.ImportPathAsync(mappingBox.Id, doc);
+        await workspace.Service.ImportPathAsync(mappingBox.Id, video);
+
+        var result = await workspace.Service.ClassifyMappingItemsAsync();
+
+        Assert.Equal(3, result.MovedCount);
+        Assert.Equal(0, result.SkippedCount);
+        var boxes = await workspace.Service.GetBoxesAsync();
+        Assert.Contains(boxes, box => box.Name == "图片收纳盒" && box.Type == BoxType.Mapping);
+        Assert.Contains(boxes, box => box.Name == "文档收纳盒" && box.Type == BoxType.Mapping);
+        Assert.Contains(boxes, box => box.Name == "视频收纳盒" && box.Type == BoxType.Mapping);
+    }
+
+    [Fact]
+    public async Task ClassifyMappingItemsAsync_SkipsStoredItemsAndReusesExistingBoxes()
+    {
+        using var workspace = await TestWorkspace.CreateAsync();
+        var normalBox = await workspace.GetBoxAsync(BoxType.Normal);
+        var mappingBox = await workspace.GetBoxAsync(BoxType.Mapping);
+        var storedFile = workspace.CreateSourceFile("classify", "stored.png", "image");
+        await workspace.Service.ImportPathAsync(normalBox.Id, storedFile);
+        var reference = workspace.CreateSourceFile("classify", "ref.png", "image");
+        await workspace.Service.ImportPathAsync(mappingBox.Id, reference);
+
+        var first = await workspace.Service.ClassifyMappingItemsAsync();
+        Assert.Equal(1, first.MovedCount);
+        Assert.Equal(1, first.SkippedCount);
+
+        // 第二次运行时引用已在分类盒内，不再产生移动。
+        var second = await workspace.Service.ClassifyMappingItemsAsync();
+        Assert.Equal(0, second.MovedCount);
+        var imageBoxes = (await workspace.Service.GetBoxesAsync())
+            .Where(box => box.Name == "图片收纳盒")
+            .ToArray();
+        Assert.Single(imageBoxes);
+    }
+
+    [Fact]
+    public void ClassifyCategory_AssignsExtensionsToExpectedCategories()
+    {
+        Assert.Equal("图片收纳盒", ClassifyCategory.GetCategory("a.JPG", null).BoxName);
+        Assert.Equal("文档收纳盒", ClassifyCategory.GetCategory("b.docx", null).BoxName);
+        Assert.Equal("视频收纳盒", ClassifyCategory.GetCategory("c.MKV", null).BoxName);
+        Assert.Equal("音频收纳盒", ClassifyCategory.GetCategory("d.flac", null).BoxName);
+        Assert.Equal("压缩包收纳盒", ClassifyCategory.GetCategory("e.zip", null).BoxName);
+        Assert.Equal("文件夹收纳盒", ClassifyCategory.GetCategory("folder", null, isDirectory: true).BoxName);
+        Assert.Equal("其他收纳盒", ClassifyCategory.GetCategory("no-extension", null).BoxName);
+        Assert.Equal("其他收纳盒", ClassifyCategory.GetCategory("f.xyz", null).BoxName);
+        Assert.Equal("其他收纳盒", ClassifyCategory.GetCategory("", null).BoxName);
+    }
+
+    [Fact]
+    public async Task MergeBoxAsync_RollsBackMovedItemsWhenLaterItemFails()
+    {
+        using var workspace = await TestWorkspace.CreateAsync();
+        var sourceBox = await workspace.Service.CreateBoxAsync("来源盒", BoxType.Normal);
+        var targetBox = await workspace.Service.CreateBoxAsync("目标盒", BoxType.Normal);
+        var firstFile = workspace.CreateSourceFile("merge-rollback", "first.txt", "a");
+        var secondFile = workspace.CreateSourceFile("merge-rollback", "second.txt", "b");
+        var firstItem = await workspace.Service.ImportPathAsync(sourceBox.Id, firstFile);
+        var secondItem = await workspace.Service.ImportPathAsync(sourceBox.Id, secondFile);
+
+        // 第二个 item 的存储文件被外部删除 → 合并中途失败。
+        File.Delete(secondItem.StoredPath!);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => workspace.Service.MergeBoxAsync(sourceBox.Id, targetBox.Id));
+
+        Assert.Contains("回滚", exception.Message);
+        // 第一个 item 应已回滚到源盒。
+        var sourceItems = await workspace.Service.GetItemsAsync(sourceBox.Id);
+        Assert.Contains(sourceItems, item => item.Id == firstItem.Id);
+        Assert.True(File.Exists(firstItem.StoredPath!), "回滚后文件应仍在源盒存储目录。");
+    }
+
+    [Fact]
+    public async Task MergeBoxAsync_PreflightRejectsStoredItemInsideMappingBox()
+    {
+        using var workspace = await TestWorkspace.CreateAsync();
+        var sourceBox = await workspace.Service.CreateBoxAsync("来源映射盒", BoxType.Mapping);
+        var targetBox = await workspace.Service.CreateBoxAsync("目标映射盒", BoxType.Mapping);
+
+        // 直接注入异常数据：映射盒里出现一条带存储路径的 item。
+        var abnormalItem = new DrawerItem(
+            Guid.NewGuid(),
+            sourceBox.Id,
+            "abnormal.txt",
+            ItemKind.File,
+            "C:\\fake\\original.txt",
+            "C:\\fake\\stored.txt",
+            0,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+        await workspace.Repository.AddItemAsync(abnormalItem);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => workspace.Service.MergeBoxAsync(sourceBox.Id, targetBox.Id));
+
+        // 源盒与目标盒都不应发生变化（直接查仓库，避开 Service 的缺失文件清理）。
+        Assert.Contains(
+            await workspace.Repository.GetItemsAsync(sourceBox.Id),
+            item => item.Id == abnormalItem.Id);
+        Assert.Empty(await workspace.Repository.GetItemsAsync(targetBox.Id));
+    }
+
+    private sealed class RecordingFileLauncher : IFileLauncher
+    {
+        public List<string> Opened { get; } = [];
+
+        public List<string> AdminOpened { get; } = [];
+
+        public List<string> Revealed { get; } = [];
+
+        public Task OpenAsync(string path, CancellationToken cancellationToken = default)
+        {
+            Opened.Add(Path.GetFullPath(path));
+            return Task.CompletedTask;
+        }
+
+        public Task OpenAsAdminAsync(string path, CancellationToken cancellationToken = default)
+        {
+            AdminOpened.Add(Path.GetFullPath(path));
+            return Task.CompletedTask;
+        }
+
+        public Task ShowInFolderAsync(string path, CancellationToken cancellationToken = default)
+        {
+            Revealed.Add(Path.GetFullPath(path));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TestWorkspace : IDisposable
+    {
+        private TestWorkspace(string root, AppPaths paths, DrawerRepository repository, DrawerService service)
+        {
+            Root = root;
+            Paths = paths;
+            Repository = repository;
+            Service = service;
+        }
+
+        public string Root { get; }
+
+        public AppPaths Paths { get; }
+
+        public DrawerRepository Repository { get; }
+
+        public DrawerService Service { get; }
+
+        public static async Task<TestWorkspace> CreateAsync()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "WitchDrawer.Tests", Guid.NewGuid().ToString("N"));
+            var paths = new AppPaths(root);
+            var repository = new DrawerRepository(paths.DatabasePath);
+            var service = new DrawerService(paths, repository);
+            await service.InitializeAsync();
+            return new TestWorkspace(root, paths, repository, service);
+        }
+
+        public string CreateSourceFile(string folderName, string fileName, string content)
+        {
+            var directory = Path.Combine(Root, "sources", folderName);
+            Directory.CreateDirectory(directory);
+            var path = Path.Combine(directory, fileName);
+            File.WriteAllText(path, content);
+            return path;
+        }
+
+        public string CreateSourceDirectory(string folderName, string nestedFileName, string content)
+        {
+            var directory = Path.Combine(Root, "sources", folderName);
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(Path.Combine(directory, nestedFileName), content);
+            return directory;
+        }
+
+        public async Task<Box> GetBoxAsync(BoxType type)
+        {
+            var boxes = await Service.GetBoxesAsync();
+            return boxes.Single(box => box.Type == type);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(Root))
+                {
+                    Directory.Delete(Root, recursive: true);
+                }
+            }
+            catch
+            {
+                // Best-effort test cleanup.
+            }
+        }
+    }
+}

--- a/tests/WitchDrawer.Core.Tests/DrawerServiceAdvancedTests.cs
+++ b/tests/WitchDrawer.Core.Tests/DrawerServiceAdvancedTests.cs
@@ -274,6 +274,39 @@ public sealed class DrawerServiceAdvancedTests
         Assert.Empty(await workspace.Repository.GetItemsAsync(targetBox.Id));
     }
 
+    [Fact]
+    public void CreateImportPermissionException_MentionsMappingBoxForPublicDesktop()
+    {
+        var commonDesktop = Environment.GetFolderPath(
+            Environment.SpecialFolder.CommonDesktopDirectory);
+        if (string.IsNullOrWhiteSpace(commonDesktop))
+        {
+            return; // 环境无公共桌面时跳过。
+        }
+
+        var sourcePath = Path.Combine(commonDesktop, "微信.lnk");
+        var exception = DrawerService.CreateImportPermissionException(
+            "微信.lnk",
+            sourcePath,
+            new UnauthorizedAccessException("Access denied"));
+
+        Assert.Contains("映射收纳盒", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("公共桌面", exception.Message, StringComparison.Ordinal);
+        Assert.IsType<UnauthorizedAccessException>(exception.InnerException);
+    }
+
+    [Fact]
+    public void CreateImportPermissionException_GenericHintForOtherReadOnlyLocations()
+    {
+        var exception = DrawerService.CreateImportPermissionException(
+            "a.txt",
+            "C:\\Program Files\\SomeApp\\a.txt",
+            new UnauthorizedAccessException("Access denied"));
+
+        Assert.Contains("映射收纳盒", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("源目录没有写入权限", exception.Message, StringComparison.Ordinal);
+    }
+
     private sealed class RecordingFileLauncher : IFileLauncher
     {
         public List<string> Opened { get; } = [];


### PR DESCRIPTION
## 变更内容

根据用户反馈清单完善/解决 8 项需求：

### 部分解决 → 完善
- **翻页/滚动/单排**：列数预设（3×3~6×6）真正参与自动放置换行；右键菜单可设行数上限（单排 1 行 / 3 行内滚动 / 不限）
- **尺寸与透明度**：设置页新增背景不透明度滑块（5%~100%，仅缩放玻璃背景 alpha，图标/文字不透明，实时预览 + 释放保存）
- **显示文件名**：图标下方文件名 + 主窗口"文件名"眼睛按钮，每盒独立持久化

### 未解决 → 解决
- **重启后重叠**：EnumDisplayMonitors 多屏枚举 + 按所在屏 clamp + 盒间碰撞级联避让
- **图标右键菜单**：打开 / 以管理员身份打开（仅文件）/ 打开文件所在位置 / 重命名 / 排序（名称·大小·类型·日期）/ 布局 / 移出到桌面 / 删除
- **单独重命名**：仅改数据库显示名，磁盘文件永不修改；.lnk 后缀自动保留
- **合并 + 一键分类**：同类盒合并（存储盒移文件、映射盒转引用，含预检与失败回滚）；按类型自动归入分类映射盒（图片/文档/视频/音频/压缩包等）
- **去角标**：快捷方式 fallback 不再渲染带箭头的通用图标（保留 IconOnly 高质图标路径）

## 质量
- 新增 18 项测试（重命名/合并/回滚/预检/分类/行数/透明度/文件名可见性等）
- 全量 197 项测试通过，构建 0 警告 0 错误
- 两轮独立审查并修复 7 个问题（透明水晶回归、拖拽落点跳行、MaxHeight 不刷新、合并无回滚、图标降级、NaN 风险等）

## 验证
- dotnet build WitchDrawer.sln：0 警告 0 错误
- dotnet test WitchDrawer.sln：197 项全部通过