### PR TITLE
feat: 用自建固定精简菜单替代原生系统右键菜单

### DIFF
--- a/src/WitchDrawer.App/ViewModels/DesktopBoxViewModel.cs
+++ b/src/WitchDrawer.App/ViewModels/DesktopBoxViewModel.cs
@@ -1136,6 +1136,24 @@ public sealed class DesktopBoxViewModel : ObservableObject
         }
     }
 
+    /// <summary>
+    /// 右键时源文件已失效（被外部删除/移动），给用户一个轻量提示而非弹出空菜单。
+    /// </summary>
+    public void ShowFileMissingNotice(DrawerItemViewModel item)
+    {
+        _logger.Info($"Context menu skipped: source path for item '{item.DisplayName}' no longer exists.");
+        StatusText = $"文件不存在：{item.DisplayName}";
+    }
+
+    /// <summary>
+    /// 菜单弹出/执行失败时记录并提示，不让异常把盒子窗口搞挂。
+    /// </summary>
+    public void ShowContextMenuFailure(DrawerItemViewModel item, Exception exception)
+    {
+        _logger.Error(exception, $"Failed to show context menu for '{item.DisplayName}'.");
+        StatusText = $"菜单打开失败：{exception.Message}";
+    }
+
     private async Task MoveItemWithinBoxAsync(DrawerItemViewModel item, int targetColumn, int targetRow)
     {
         var targetSlot = NormalizeGridSlot(targetColumn, targetRow);

--- a/src/WitchDrawer.App/Views/DesktopBoxWindow.xaml
+++ b/src/WitchDrawer.App/Views/DesktopBoxWindow.xaml
@@ -499,7 +499,8 @@
                      SelectionChanged="OnItemsSelectionChanged"
                      PreviewMouseLeftButtonDown="OnIconPreviewMouseLeftButtonDown"
                      MouseMove="OnIconMouseMove"
-                     MouseDoubleClick="OnItemsMouseDoubleClick">
+                     MouseDoubleClick="OnItemsMouseDoubleClick"
+                     PreviewMouseRightButtonUp="OnIconPreviewMouseRightButtonUp">
                 <ListBox.Style>
                     <Style TargetType="{x:Type ListBox}" BasedOn="{StaticResource {x:Type ListBox}}">
                         <Setter Property="Visibility" Value="Visible" />
@@ -682,7 +683,8 @@
                      SelectionChanged="OnItemsSelectionChanged"
                      PreviewMouseLeftButtonDown="OnIconPreviewMouseLeftButtonDown"
                      MouseMove="OnIconMouseMove"
-                     MouseDoubleClick="OnItemsMouseDoubleClick">
+                     MouseDoubleClick="OnItemsMouseDoubleClick"
+                     PreviewMouseRightButtonUp="OnIconPreviewMouseRightButtonUp">
                 <ListBox.Style>
                     <Style TargetType="{x:Type ListBox}" BasedOn="{StaticResource {x:Type ListBox}}">
                         <Setter Property="Visibility" Value="Collapsed" />
@@ -1072,7 +1074,8 @@
                                                 Margin="0"
                                                 ToolTip="{Binding PathLabel}"
                                                 Click="OnDrawerSecondaryItemClick"
-                                                PreviewMouseLeftButtonDown="OnDrawerSecondaryIconPreviewMouseLeftButtonDown">
+                                                PreviewMouseLeftButtonDown="OnDrawerSecondaryIconPreviewMouseLeftButtonDown"
+                                                PreviewMouseRightButtonUp="OnDrawerSecondaryIconMouseRightButtonUp">
                                             <Border Width="{Binding DataContext.LayoutSettings.DrawerPrimaryIconFrameSize, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
                                                     Height="{Binding DataContext.LayoutSettings.DrawerPrimaryIconFrameSize, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
                                                     CornerRadius="{Binding DataContext.LayoutSettings.IconCornerRadius, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
@@ -1137,6 +1140,7 @@
                                 <Grid>
                                     <Button Style="{StaticResource DrawerTileButtonStyle}"
                                             PreviewMouseLeftButtonDown="OnDrawerIconPreviewMouseLeftButtonDown"
+                                            PreviewMouseRightButtonUp="OnDrawerCoverIconMouseRightButtonUp"
                                             ToolTip="{Binding Item.PathLabel}"
                                             Visibility="{Binding HasItem, Converter={StaticResource BooleanToVisibilityConverter}}">
                                         <Border Width="{Binding DataContext.LayoutSettings.DrawerPrimaryIconFrameSize, RelativeSource={RelativeSource AncestorType=Window}}"

--- a/src/WitchDrawer.App/Views/DesktopBoxWindow.xaml.cs
+++ b/src/WitchDrawer.App/Views/DesktopBoxWindow.xaml.cs
@@ -10,6 +10,7 @@ using System.Windows.Media.Animation;
 using System.Windows.Threading;
 using WitchDrawer.App.Infrastructure;
 using WitchDrawer.App.ViewModels;
+using WitchDrawer.Native.Shell;
 using WitchDrawer.Native.Windows;
 
 namespace WitchDrawer.App.Views;
@@ -1856,6 +1857,137 @@ public partial class DesktopBoxWindow : Window
         if (TryGetDrawerItem(e.OriginalSource, out var drawerItem))
         {
             await ViewModel.OpenItemCommand.ExecuteAsync(drawerItem);
+        }
+    }
+
+    private void OnIconPreviewMouseRightButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        // 主网格/映射列表：右键对象是 ListBox 里的项。
+        if (!TryGetDrawerItem(e.OriginalSource, out var drawerItem))
+        {
+            return;
+        }
+
+        e.Handled = true;
+        SelectItem(drawerItem.Id);
+        ShowContextMenuForItem(drawerItem, e);
+    }
+
+    private void OnDrawerCoverIconMouseRightButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        // 抽屉折叠封面磁贴：DataContext 是 DrawerCoverTileViewModel，真正的项在 Item。
+        // 仅对「有项目」的磁贴响应；「展开抽屉」磁贴（IsExpandTile）无 Item，忽略。
+        if (sender is not Button { DataContext: DrawerCoverTileViewModel { Item: not null } tile })
+        {
+            return;
+        }
+
+        e.Handled = true;
+        SelectCoverTile(tile);
+        ShowContextMenuForItem(tile.Item, e);
+    }
+
+    private void OnDrawerSecondaryIconMouseRightButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        // 抽屉展开后的二级弹窗磁贴：DataContext 就是 DrawerItemViewModel。
+        if (sender is not Button { DataContext: DrawerItemViewModel item })
+        {
+            return;
+        }
+
+        e.Handled = true;
+        ShowContextMenuForItem(item, e);
+    }
+
+    /// <summary>
+    /// 为指定收纳项弹出固定精简的原生右键菜单（打开 / 管理员运行 / 属性 / 复制 / 移除）。
+    /// 不再使用 Windows 系统右键菜单，因此不会混入第三方 Shell 扩展，菜单保持可控。
+    /// </summary>
+    private async void ShowContextMenuForItem(DrawerItemViewModel drawerItem, MouseButtonEventArgs e)
+    {
+        ClearPendingIconDrag();
+
+        var path = drawerItem.PathLabel;
+        if (string.IsNullOrWhiteSpace(path)
+            || (!File.Exists(path) && !Directory.Exists(path)))
+        {
+            // 源文件已失效（被外部删除/移动）：不弹空菜单，给轻提示。
+            ViewModel.ShowFileMissingNotice(drawerItem);
+            return;
+        }
+
+        var ownerHandle = NativeHandle;
+        if (ownerHandle == nint.Zero)
+        {
+            return;
+        }
+
+        // 用 GetCursorPos 拿物理屏幕坐标（TrackPopupMenu 需要屏幕像素坐标，不受 WPF
+        // DIP/DPI 缩放和多显示器坐标空间影响；e.GetPosition(null) 会导致菜单错位）。
+        if (!NativeCursor.TryGetCursorPos(out var screenX, out var screenY))
+        {
+            return;
+        }
+
+        ItemContextAction action;
+        try
+        {
+            action = ItemContextMenu.Show(
+                ownerHandle,
+                showRunAs: IsExecutable(path),
+                screenX,
+                screenY);
+        }
+        catch (Exception exception)
+        {
+            ViewModel.ShowContextMenuFailure(drawerItem, exception);
+            return;
+        }
+
+        switch (action)
+        {
+            case ItemContextAction.Open:
+                await ViewModel.OpenItemCommand.ExecuteAsync(drawerItem);
+                break;
+
+            case ItemContextAction.RunAsAdministrator:
+                // 返回 false 仅在 ShellExecuteEx 真正失败（非用户取消）时；极罕见，静默即可。
+                ItemContextMenu.TryRunAsAdministrator(path);
+                break;
+
+            case ItemContextAction.Properties:
+                ItemContextMenu.TryShowProperties(path);
+                break;
+
+            case ItemContextAction.Copy:
+                CopyToClipboard(path);
+                break;
+
+            case ItemContextAction.RemoveFromBox:
+                await ViewModel.DeleteItemCommand.ExecuteAsync(drawerItem);
+                break;
+        }
+    }
+
+    private static bool IsExecutable(string path)
+    {
+        var extension = Path.GetExtension(path);
+        var isFile = !Directory.Exists(path);
+        // .lnk 快捷方式通常指向可执行程序，一并视为「可用管理员身份运行」。
+        return isFile && extension.ToUpperInvariant() is ".EXE" or ".BAT" or ".CMD" or ".COM" or ".MSI" or ".LNK";
+    }
+
+    private static void CopyToClipboard(string path)
+    {
+        try
+        {
+            var data = new System.Windows.DataObject();
+            data.SetFileDropList(new System.Collections.Specialized.StringCollection { path });
+            System.Windows.Clipboard.SetDataObject(data, copy: true);
+        }
+        catch
+        {
+            // 剪贴板可能被其它进程占用；失败时静默，不打断用户。
         }
     }
 

--- a/src/WitchDrawer.Native/Shell/ItemContextMenu.cs
+++ b/src/WitchDrawer.Native/Shell/ItemContextMenu.cs
@@ -1,0 +1,202 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace WitchDrawer.Native.Shell;
+
+/// <summary>
+/// 收纳项右键菜单里用户可执行的、可控的精简动作。
+/// </summary>
+public enum ItemContextAction
+{
+    /// <summary>没有选择（点击其它区域关闭菜单）。</summary>
+    None,
+
+    /// <summary>用默认程序打开文件/文件夹（仅普通文件/文件夹显示，作为第一项）。</summary>
+    Open,
+
+    /// <summary>以管理员身份运行（仅对可执行文件显示，作为第一项）。</summary>
+    RunAsAdministrator,
+
+    /// <summary>打开系统「属性」对话框。</summary>
+    Properties,
+
+    /// <summary>复制文件/文件夹到剪贴板（不改动原文件）。</summary>
+    Copy,
+
+    /// <summary>从收纳盒移除（由 WitchDrawer 安全服务原位还原）。</summary>
+    RemoveFromBox,
+}
+
+/// <summary>
+/// 为收纳项弹出一个固定、精简的原生右键菜单（不依赖 Windows 系统右键菜单，
+/// 因此不会混入 7-Zip、杀毒、Git 等第三方 Shell 扩展，也不受系统语言影响）。
+///
+/// 菜单只保留与「桌面文件收纳」定位相符的几条:打开 / 以管理员身份运行 / 属性 /
+/// 复制 / 移除。删除、重命名、剪切等会绕过 WitchDrawer 数据一致性的动作一律不提供。
+/// </summary>
+public static class ItemContextMenu
+{
+    private const int CommandOpen = 1;
+    private const int CommandRunAs = 2;
+    private const int CommandProperties = 3;
+    private const int CommandCopy = 4;
+    private const int CommandRemove = 5;
+
+    private const uint MfString = 0x0000;
+    private const uint MfSeparator = 0x0800;
+
+    private const uint TpmReturnCmd = 0x0100;
+    private const uint TpmNonotify = 0x0080;
+    private const uint TpmRightButton = 0x0002;
+
+    /// <summary>
+    /// 弹出菜单并返回用户选择的动作。必须在 WPF UI 线程调用，且 <paramref name="ownerHandle"/>
+    /// 必须是有效的窗口句柄。
+    /// </summary>
+    /// <param name="ownerHandle">拥有菜单的窗口句柄。</param>
+    /// <param name="showRunAs">是否显示「以管理员身份运行」项（调用方按文件扩展名决定）。</param>
+    /// <param name="screenX">弹出位置的屏幕物理 X 坐标。</param>
+    /// <param name="screenY">弹出位置的屏幕物理 Y 坐标。</param>
+    public static ItemContextAction Show(
+        nint ownerHandle,
+        bool showRunAs,
+        int screenX,
+        int screenY)
+    {
+        var menu = NativeMethods.CreatePopupMenu();
+        if (menu == nint.Zero)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "CreatePopupMenu failed.");
+        }
+
+        try
+        {
+            // 第一项：可执行文件用「以管理员身份运行」（提权打开），普通文件/文件夹
+            // 用「打开」（它们无法提权）。
+            if (showRunAs)
+            {
+                NativeMethods.AppendMenuW(menu, MfString, CommandRunAs, "以管理员身份运行");
+            }
+            else
+            {
+                NativeMethods.AppendMenuW(menu, MfString, CommandOpen, "打开");
+            }
+
+            NativeMethods.AppendMenuW(menu, MfSeparator, 0, string.Empty);
+            NativeMethods.AppendMenuW(menu, MfString, CommandProperties, "属性");
+            NativeMethods.AppendMenuW(menu, MfString, CommandCopy, "复制");
+            NativeMethods.AppendMenuW(menu, MfSeparator, 0, string.Empty);
+            NativeMethods.AppendMenuW(menu, MfString, CommandRemove, "从收纳盒移除");
+
+            var commandId = NativeMethods.TrackPopupMenuEx(
+                menu,
+                TpmReturnCmd | TpmNonotify | TpmRightButton,
+                screenX,
+                screenY,
+                ownerHandle,
+                nint.Zero);
+
+            return commandId switch
+            {
+                CommandOpen => ItemContextAction.Open,
+                CommandRunAs => ItemContextAction.RunAsAdministrator,
+                CommandProperties => ItemContextAction.Properties,
+                CommandCopy => ItemContextAction.Copy,
+                CommandRemove => ItemContextAction.RemoveFromBox,
+                _ => ItemContextAction.None,
+            };
+        }
+        finally
+        {
+            NativeMethods.DestroyMenu(menu);
+        }
+    }
+
+    /// <summary>
+    /// 以管理员身份运行 <paramref name="path"/>，通过 ShellExecuteEx 的 runas verb 触发
+    /// UAC 提权对话框。
+    /// </summary>
+    public static bool TryRunAsAdministrator(string path)
+    {
+        return TryShellExecute(path, "runas");
+    }
+
+    /// <summary>
+    /// 打开 <paramref name="path"/> 的系统「属性」对话框。
+    /// </summary>
+    public static bool TryShowProperties(string path)
+    {
+        return TryShellExecute(path, "properties");
+    }
+
+    private static bool TryShellExecute(string path, string verb)
+    {
+        var info = new ShellExecuteInfo
+        {
+            cbSize = Marshal.SizeOf<ShellExecuteInfo>(),
+            fMask = 0,
+            hwnd = nint.Zero,
+            lpVerb = verb,
+            lpFile = path,
+            lpParameters = null,
+            lpDirectory = Path.GetDirectoryName(path),
+            nShow = 1, // SW_SHOWNORMAL
+        };
+
+        if (!NativeMethods.ShellExecuteExW(ref info))
+        {
+            // ERROR_CANCELLED=0x000004C7：用户在 UAC 上点了「否」，不算错误。
+            return Marshal.GetLastWin32Error() == 0x000004C7;
+        }
+
+        if (info.hProcess != nint.Zero)
+        {
+            NativeMethods.CloseHandle(info.hProcess);
+        }
+
+        return true;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct ShellExecuteInfo
+    {
+        public int cbSize;
+        public uint fMask;
+        public nint hwnd;
+        public string? lpVerb;
+        public string? lpFile;
+        public string? lpParameters;
+        public string? lpDirectory;
+        public int nShow;
+        public nint hInstApp;
+        public nint lpIDList;
+        public string? lpClass;
+        public nint hkeyClass;
+        public uint dwHotKey;
+        public nint hIcon;
+        public nint hProcess;
+    }
+
+    private static class NativeMethods
+    {
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern nint CreatePopupMenu();
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern bool DestroyMenu(nint hMenu);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool AppendMenuW(nint hMenu, uint uFlags, nint uIDNewItem, string lpNewItem);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern int TrackPopupMenuEx(nint hMenu, uint uFlags, int x, int y, nint hwnd, nint lptpm);
+
+        [DllImport("shell32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool ShellExecuteExW(ref ShellExecuteInfo pExecInfo);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool CloseHandle(nint hObject);
+    }
+}

--- a/src/WitchDrawer.Native/Shell/NativeCursor.cs
+++ b/src/WitchDrawer.Native/Shell/NativeCursor.cs
@@ -1,0 +1,33 @@
+using System.Runtime.InteropServices;
+
+namespace WitchDrawer.Native.Shell;
+
+/// <summary>
+/// 获取当前鼠标光标的物理屏幕坐标，用于 <see cref="ItemContextMenu"/> 精确定位
+/// 原生菜单的弹出位置（<c>TrackPopupMenu</c> 需要的是屏幕像素坐标，不受 WPF 的
+/// DIP/DPI 缩放与多显示器坐标空间影响）。
+/// </summary>
+public static class NativeCursor
+{
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Point
+    {
+        public int X;
+        public int Y;
+    }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetCursorPos(out Point lpPoint);
+
+    /// <summary>
+    /// 返回当前光标物理屏幕坐标（像素）。失败时返回 <see langword="false"/>。
+    /// </summary>
+    public static bool TryGetCursorPos(out int x, out int y)
+    {
+        var success = GetCursorPos(out var point);
+        x = point.X;
+        y = point.Y;
+        return success;
+    }
+}


### PR DESCRIPTION
## 背景

本 PR 用**自建固定精简菜单**替代此前回退的原生系统右键菜单（IContextMenu）。

之前原生方案会把 7-Zip、杀毒、Git 等第三方 Shell 扩展一并带进来，导致菜单臃肿、且删除/重命名/剪切等动作会绕过 Core 服务、破坏「原位还原 + 数据一致性」。

## 本方案的取舍

- 菜单只保留 5 项：**打开（可执行文件为「以管理员身份运行」）· 属性 · 复制 · 从收纳盒移除**。
- **不依赖 IContextMenu**，无第三方扩展、无子菜单、无臃肿，也不受系统语言影响。
- **删除 / 重命名 / 剪切一律不提供**，避免绕过 Core 服务的文件变更；「打开」「移除」均走既有 Core 服务。
- 只用了 TrackPopupMenuEx + ShellExecuteEx(runas/properties) 两个 Shell 调用，复杂度极低。

## 改动文件

- 新增 ItemContextMenu.cs、NativeCursor.cs
- DesktopBoxWindow.xaml(.cs)：挂右键事件并分派动作
- DesktopBoxViewModel.cs：补回源文件失效提示与菜单失败兜底

## 协议

本项目遵循 CC BY-NC-SA 4.0，原作者 Thewitchcat。此 PR 以相同协议共享。