### PR TITLE
feat(desktop-box):接入普通/待办/映射盒自由拖动大小

### DIFF
--- a/src/WitchDrawer.App/Infrastructure/DesktopBoxManager.cs
+++ b/src/WitchDrawer.App/Infrastructure/DesktopBoxManager.cs
@@ -187,12 +187,14 @@ public sealed class DesktopBoxManager
                     await viewModel.LoadFileNameVisibilityAsync();
                     await viewModel.LoadMappingViewModeAsync();
                     await viewModel.LoadMappingListWidthAsync();
+                    await viewModel.LoadMappingListHeightAsync();
                     // The persisted drawer height is snapped against the active row height.
                     // Load the file-name row first so a saved 4x4 cover stays 4x4 after restart.
                     await viewModel.LoadDrawerCoverSizeAsync();
                     await viewModel.LoadRollUpStateAsync();
                     await viewModel.LoadSortModeAsync();
                     await viewModel.LoadSizeModeAsync();
+                    await viewModel.LoadTodoBoxSizeAsync();
                     viewModel.ItemsChanged += (_, _) => ItemsChanged?.Invoke(
                         this,
                         new BoxItemsChangedEventArgs(viewModel.BoxId));

--- a/src/WitchDrawer.App/ViewModels/BoxViewModel.cs
+++ b/src/WitchDrawer.App/ViewModels/BoxViewModel.cs
@@ -114,7 +114,7 @@ public sealed partial class BoxViewModel : ObservableObject
     public string TitleVisibilityAutomationName => IsTitleVisible ? "隐藏名称" : "显示名称";
 
     public bool SupportsFileNameVisibility =>
-        Type is BoxType.Normal or BoxType.Pixel or BoxType.Drawer;
+        Type is BoxType.Normal or BoxType.Pixel or BoxType.Drawer or BoxType.Mapping;
 
     public bool IsFileNameVisible => _isFileNameVisible;
 

--- a/src/WitchDrawer.App/ViewModels/DesktopBoxViewModel.cs
+++ b/src/WitchDrawer.App/ViewModels/DesktopBoxViewModel.cs
@@ -38,6 +38,8 @@ public sealed class DesktopBoxViewModel : ObservableObject
     private const string FileNameVisibilitySettingPrefix = "BoxFileNameVisible:";
     private const string RollUpSettingPrefix = "BoxRolledUp:";
     private const string DrawerSortModeSettingPrefix = "DrawerSortMode:";
+    private const string TodoBoxSizeSettingPrefix = "TodoBoxSize:";
+    private const string MappingListHeightSettingPrefix = "MappingListHeight:";
     private const double DefaultDrawerCoverWidth = 180;
     private const double DefaultDrawerCoverHeight = 112;
     private const double MaximumDrawerCoverDimension = 720;
@@ -45,6 +47,12 @@ public sealed class DesktopBoxViewModel : ObservableObject
     private const double DrawerTitleHeightCompensation = DesktopBoxLayoutSettings.HiddenGridContentInset;
     internal const double MinimumMappingListWidth = 180;
     internal const double MaximumMappingListWidth = 720;
+    private const double DefaultTodoBoxWidth = 310;
+    private const double DefaultTodoBoxHeight = 320;
+    private const double MinimumTodoBoxWidth = 240;
+    private const double MaximumTodoBoxWidth = 720;
+    private const double MinimumTodoBoxHeight = 160;
+    private const double MaximumTodoBoxHeight = 720;
 
     private readonly DrawerService _drawerService;
     private readonly TodoService _todoService;
@@ -86,6 +94,9 @@ public sealed class DesktopBoxViewModel : ObservableObject
     private BoxSizeModeState _sizeMode = BoxSizeModeState.Adaptive;
     private int _occupiedColumns = 1;
     private int _occupiedRows = 1;
+    private double _todoBoxWidth = DefaultTodoBoxWidth;
+    private double _todoBoxHeight = DefaultTodoBoxHeight;
+    private double? _mappingListHeightOverride;
 
     public DesktopBoxViewModel(
         Box box,
@@ -121,6 +132,13 @@ public sealed class DesktopBoxViewModel : ObservableObject
     public DesktopBoxLayoutSettings LayoutSettings => _layoutSettings;
 
     public double MappingListWidth => _mappingListWidth;
+
+    /// <summary>
+    /// 映射盒列表模式的有效高度：用户拖动覆盖的固定值优先；未拖动时回退到
+    /// 当前 preset 的 MappingListMaxHeight（与 MinHeight 取大值保证行内容可见）。
+    /// </summary>
+    public double MappingListHeight => _mappingListHeightOverride
+        ?? Math.Max(LayoutSettings.MappingListMinHeight, LayoutSettings.MappingListMaxHeight);
 
     /// <summary>供窗口层包装 fire-and-forget 任务时记录异常。</summary>
     internal IAppLogger Logger => _logger;
@@ -191,11 +209,20 @@ public sealed class DesktopBoxViewModel : ObservableObject
     /// <summary>
     /// 固定 m×n 格尺寸仅适用于普通网格收纳盒；其余盒型始终自适应。
     /// </summary>
-    public bool SupportsFixedSize => Type is BoxType.Normal or BoxType.Pixel;
+    public bool SupportsFixedSize => Type is BoxType.Normal or BoxType.Pixel or BoxType.Mapping;
 
     public BoxSizeModeState SizeMode => _sizeMode;
 
     public bool IsFixedSize => SupportsFixedSize && _sizeMode.IsFixed;
+
+    public bool ShowFixedResizeHandle =>
+        SupportsFixedSize
+        && !IsTodoBox
+        && !(IsMappingBox && IsMappingListMode);
+
+    public double TodoBoxWidth => _todoBoxWidth;
+
+    public double TodoBoxHeight => _todoBoxHeight;
 
     /// <summary>
     /// 网格视口宽度：固定模式下按 m×n 格物理尺寸 + 共享 chrome 预留渲染，
@@ -1143,6 +1170,7 @@ public sealed class DesktopBoxViewModel : ObservableObject
             }
 
             OnPropertyChanged(nameof(IsGridMode));
+            OnPropertyChanged(nameof(ShowFixedResizeHandle));
             OnPropertyChanged(nameof(HeaderRowHeight));
             HideDragPreview();
             UpdateItemIconSizes();
@@ -1727,6 +1755,174 @@ public sealed class DesktopBoxViewModel : ObservableObject
             $"{DrawerCoverWidth:0.##},{DrawerCoverHeight:0.##}");
         return _drawerService.SetSettingAsync(GetDrawerCoverSizeSettingKey(BoxId), value);
     }
+
+    public void ResizeTodoBox(double width, double height)
+    {
+        if (!IsTodoBox)
+        {
+            return;
+        }
+
+        var clampedWidth = double.IsFinite(width)
+            ? Math.Clamp(width, MinimumTodoBoxWidth, MaximumTodoBoxWidth)
+            : _todoBoxWidth;
+        var clampedHeight = double.IsFinite(height)
+            ? Math.Clamp(height, MinimumTodoBoxHeight, MaximumTodoBoxHeight)
+            : _todoBoxHeight;
+        SetProperty(ref _todoBoxWidth, clampedWidth, nameof(TodoBoxWidth));
+        SetProperty(ref _todoBoxHeight, clampedHeight, nameof(TodoBoxHeight));
+    }
+
+    public async Task LoadTodoBoxSizeAsync()
+    {
+        if (!IsTodoBox)
+        {
+            return;
+        }
+
+        try
+        {
+            var saved = await _drawerService.GetSettingAsync(GetTodoBoxSizeSettingKey(BoxId));
+            if (TryParseDrawerCoverSize(saved, out var width, out var height))
+            {
+                ResizeTodoBox(width, height);
+            }
+        }
+        catch (Exception exception)
+        {
+            _logger.Error(exception, "Failed to load todo box size.");
+        }
+    }
+
+    public Task SaveTodoBoxSizeAsync()
+    {
+        if (!IsTodoBox)
+        {
+            return Task.CompletedTask;
+        }
+
+        var value = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{_todoBoxWidth:0.##},{_todoBoxHeight:0.##}");
+        return _drawerService.SetSettingAsync(GetTodoBoxSizeSettingKey(BoxId), value);
+    }
+
+    public void ResizeMappingListHeight(double heightDip)
+    {
+        if (!IsMappingBox)
+        {
+            return;
+        }
+
+        // 吸附到行高整数倍,避免像素级自由缩放导致的视觉错位
+        var rowHeight = Math.Max(1, LayoutSettings.MappingListRowHeight);
+
+        var min = LayoutSettings.MappingListMinHeight;
+        var max = Math.Max(min, LayoutSettings.MappingListMaxHeight);
+        double? newOverride;
+        if (!double.IsFinite(heightDip))
+        {
+            newOverride = null;
+        }
+        else if (heightDip >= max - rowHeight * 0.5)
+        {
+            // 拖到接近 layout max 时视为清空覆写,回到默认行高
+            newOverride = null;
+        }
+        else
+        {
+            var snapped = Math.Round(heightDip / rowHeight) * rowHeight;
+            newOverride = Math.Clamp(snapped, min, max);
+        }
+
+        if (Nullable.Equals(_mappingListHeightOverride, newOverride))
+        {
+            return;
+        }
+
+        _mappingListHeightOverride = newOverride;
+        OnPropertyChanged(nameof(MappingListHeight));
+    }
+
+    public async Task LoadMappingListHeightAsync()
+    {
+        if (!IsMappingBox)
+        {
+            return;
+        }
+
+        try
+        {
+            var saved = await _drawerService.GetSettingAsync(GetMappingListHeightSettingKey(BoxId));
+            if (double.TryParse(saved, NumberStyles.Float, CultureInfo.InvariantCulture, out var height)
+                && double.IsFinite(height))
+            {
+                ResizeMappingListHeight(height);
+            }
+        }
+        catch (Exception exception)
+        {
+            _logger.Error(exception, "Failed to load mapping list height.");
+        }
+    }
+
+    public Task SaveMappingListHeightAsync()
+    {
+        if (!IsMappingBox)
+        {
+            return Task.CompletedTask;
+        }
+
+        var height = _mappingListHeightOverride;
+        var key = GetMappingListHeightSettingKey(BoxId);
+        if (height is null)
+        {
+            return _drawerService.DeleteSettingAsync(key);
+        }
+
+        return _drawerService.SetSettingAsync(
+            key,
+            height.Value.ToString("R", CultureInfo.InvariantCulture));
+    }
+
+    public void ResizeFixedGrid(double widthDip, double heightDip)
+    {
+        if (!SupportsFixedSize)
+        {
+            return;
+        }
+
+        var slotWidth = Math.Max(1, LayoutSettings.ItemSlotWidth);
+        var slotHeight = Math.Max(1, LayoutSettings.ItemSlotHeight);
+        var cols = double.IsFinite(widthDip)
+            ? Math.Max(1, (int)Math.Round(widthDip / slotWidth))
+            : _sizeMode.Columns;
+        var rows = double.IsFinite(heightDip)
+            ? Math.Max(1, (int)Math.Round(heightDip / slotHeight))
+            : _sizeMode.Rows;
+
+        var clampedColumns = BoxSizeModeState.ClampColumns(Math.Max(cols, OccupiedColumns));
+        var clampedRows = BoxSizeModeState.ClampRows(Math.Max(rows, OccupiedRows));
+        ApplySizeMode(new BoxSizeModeState(true, clampedColumns, clampedRows));
+    }
+
+    public Task SaveSizeModeAsync()
+    {
+        if (!SupportsFixedSize)
+        {
+            return Task.CompletedTask;
+        }
+
+        return _drawerService.SetSettingAsync(
+            BoxViewModel.GetSizeModeSettingKey(BoxId),
+            _sizeMode.Serialize());
+    }
+
+    internal static string GetTodoBoxSizeSettingKey(Guid boxId) =>
+        $"{TodoBoxSizeSettingPrefix}{boxId:N}";
+
+    internal static string GetMappingListHeightSettingKey(Guid boxId) =>
+        $"{MappingListHeightSettingPrefix}{boxId:N}";
 
     internal static string GetDrawerCoverSizeSettingKey(Guid boxId) =>
         $"{DrawerCoverSizeSettingPrefix}{boxId:N}";

--- a/src/WitchDrawer.App/Views/DesktopBoxWindow.xaml
+++ b/src/WitchDrawer.App/Views/DesktopBoxWindow.xaml
@@ -436,12 +436,41 @@
                 </ListBox.ItemTemplate>
             </ListBox>
 
+            <!-- 普通 / 像素网格盒固定 m×n 模式下的自由拖动 Thumb：右下角斜向，溢出到 border 外便于抓握 -->
+            <Thumb x:Name="FixedGridResizeThumb"
+                   Grid.Row="1"
+                   Panel.ZIndex="12"
+                   Width="20"
+                   Height="20"
+                   HorizontalAlignment="Right"
+                   VerticalAlignment="Bottom"
+                   Margin="0,0,-8,-8"
+                   Cursor="SizeNWSE"
+                   Opacity="0.42"
+                   Visibility="{Binding ShowFixedResizeHandle, Converter={StaticResource BooleanToVisibilityConverter}}"
+                   DragStarted="OnFixedGridResizeStarted"
+                   DragDelta="OnFixedGridResizeDelta"
+                   DragCompleted="OnFixedGridResizeCompleted">
+                <Thumb.Template>
+                    <ControlTemplate TargetType="{x:Type Thumb}">
+                        <Grid Background="Transparent">
+                            <Path Data="M 5,15 L 15,5 M 10,15 L 15,10"
+                                  Stroke="{DynamicResource TextMutedBrush}"
+                                  StrokeThickness="1.4"
+                                  StrokeStartLineCap="Round"
+                                  StrokeEndLineCap="Round" />
+                        </Grid>
+                    </ControlTemplate>
+                </Thumb.Template>
+            </Thumb>
+
             <ListBox x:Name="FileList"
                      Grid.Row="1"
                      Panel.ZIndex="1"
                       Width="{Binding MappingListWidth}"
+                      Height="{Binding MappingListHeight}"
                       MinHeight="{Binding LayoutSettings.MappingListMinHeight}"
-                      MaxHeight="{Binding LayoutSettings.MappingListMaxHeight}"
+                      MaxHeight="{Binding MappingListHeight}"
                       Margin="{Binding LayoutSettings.MappingListMargin}"
                       Padding="{Binding LayoutSettings.MappingListPadding}"
                      HorizontalAlignment="Left"
@@ -580,12 +609,33 @@
                 </Thumb.Template>
             </Thumb>
 
+            <!-- 映射盒列表模式垂直拖动：底部一行，不与 FileList 重叠命中 -->
+            <Thumb x:Name="MappingListResizeHeightThumb"
+                   Grid.Row="1"
+                   Panel.ZIndex="12"
+                   Height="10"
+                   Margin="5,0,5,-1"
+                   HorizontalAlignment="Stretch"
+                   VerticalAlignment="Bottom"
+                   Cursor="SizeNS"
+                   Visibility="{Binding IsMappingListMode, Converter={StaticResource BooleanToVisibilityConverter}}"
+                   DragStarted="OnMappingListHeightResizeStarted"
+                   DragDelta="OnMappingListHeightResizeDelta"
+                   DragCompleted="OnMappingListHeightResizeCompleted">
+                <Thumb.Template>
+                    <ControlTemplate TargetType="{x:Type Thumb}">
+                        <Grid Background="Transparent" />
+                    </ControlTemplate>
+                </Thumb.Template>
+            </Thumb>
+
             <!-- 待办收纳盒：与文件盒共用原生桌面浮窗外壳，但拥有独立的持久化内容。 -->
             <Grid Grid.Row="1"
                   Panel.ZIndex="3"
-                  Width="310"
-                  MinHeight="190"
-                  MaxHeight="430"
+                  Width="{Binding TodoBoxWidth}"
+                  Height="{Binding TodoBoxHeight}"
+                  MinHeight="160"
+                  MaxHeight="720"
                   Margin="8,4,8,10"
                   HorizontalAlignment="Left"
                   VerticalAlignment="Top">
@@ -794,6 +844,32 @@
                         </ListBox.ItemTemplate>
                     </ListBox>
                 </Grid>
+
+                <!-- 待办盒右下角斜向拖动 Thumb：与抽屉盒一致样式，溢出到 border 外便于抓握 -->
+                <Thumb Grid.RowSpan="3"
+                       Panel.ZIndex="20"
+                       Width="20"
+                       Height="20"
+                       HorizontalAlignment="Right"
+                       VerticalAlignment="Bottom"
+                       Margin="0,0,-8,-8"
+                       Cursor="SizeNWSE"
+                       Opacity="0.42"
+                       DragStarted="OnTodoBoxResizeStarted"
+                       DragDelta="OnTodoBoxResizeDelta"
+                       DragCompleted="OnTodoBoxResizeCompleted">
+                    <Thumb.Template>
+                        <ControlTemplate TargetType="{x:Type Thumb}">
+                            <Grid Background="Transparent">
+                                <Path Data="M 5,15 L 15,5 M 10,15 L 15,10"
+                                      Stroke="{DynamicResource TextMutedBrush}"
+                                      StrokeThickness="1.4"
+                                      StrokeStartLineCap="Round"
+                                      StrokeEndLineCap="Round" />
+                            </Grid>
+                        </ControlTemplate>
+                    </Thumb.Template>
+                </Thumb>
             </Grid>
 
             <Popup x:Name="DrawerSecondaryPopup"

--- a/src/WitchDrawer.App/Views/DesktopBoxWindow.xaml.cs
+++ b/src/WitchDrawer.App/Views/DesktopBoxWindow.xaml.cs
@@ -46,6 +46,14 @@ public partial class DesktopBoxWindow : Window
     private NativePoint _drawerResizeStartCursor;
     private double _mappingListResizeStartWidth;
     private NativePoint _mappingListResizeStartCursor;
+    private double _todoBoxResizeStartWidth;
+    private double _todoBoxResizeStartHeight;
+    private NativePoint _todoBoxResizeStartCursor;
+    private double _fixedGridResizeStartWidth;
+    private double _fixedGridResizeStartHeight;
+    private NativePoint _fixedGridResizeStartCursor;
+    private double _mappingListHeightResizeStartHeight;
+    private NativePoint _mappingListHeightResizeStartCursor;
     private bool _suppressDrawerItemClick;
     private bool _isBoxOpacityRefreshQueued;
     private bool _isVisibleBoundsClampingEnabled;
@@ -703,6 +711,159 @@ public partial class DesktopBoxWindow : Window
         }
 
         await ViewModel.SaveMappingListWidthAsync();
+        e.Handled = true;
+    }
+
+    private void OnTodoBoxResizeStarted(object sender, DragStartedEventArgs e)
+    {
+        _todoBoxResizeStartWidth = ViewModel.TodoBoxWidth;
+        _todoBoxResizeStartHeight = ViewModel.TodoBoxHeight;
+        GetCursorPos(out _todoBoxResizeStartCursor);
+        e.Handled = true;
+    }
+
+    private void OnTodoBoxResizeDelta(object sender, DragDeltaEventArgs e)
+    {
+        if (!GetCursorPos(out var currentCursor))
+        {
+            return;
+        }
+
+        var horizontalDelta = currentCursor.X - _todoBoxResizeStartCursor.X;
+        var verticalDelta = currentCursor.Y - _todoBoxResizeStartCursor.Y;
+        var dpi = VisualTreeHelper.GetDpi(this);
+        ViewModel.ResizeTodoBox(
+            _todoBoxResizeStartWidth + (horizontalDelta / Math.Max(0.1, dpi.DpiScaleX)),
+            _todoBoxResizeStartHeight + (verticalDelta / Math.Max(0.1, dpi.DpiScaleY)));
+        e.Handled = true;
+    }
+
+    private async void OnTodoBoxResizeCompleted(object sender, DragCompletedEventArgs e)
+    {
+        if (e.Canceled)
+        {
+            ViewModel.ResizeTodoBox(_todoBoxResizeStartWidth, _todoBoxResizeStartHeight);
+            e.Handled = true;
+            return;
+        }
+
+        try
+        {
+            await ViewModel.SaveTodoBoxSizeAsync();
+        }
+        catch (Exception exception)
+        {
+            ViewModel.ResizeTodoBox(
+                _todoBoxResizeStartWidth,
+                _todoBoxResizeStartHeight);
+            _ = exception;
+        }
+
+        e.Handled = true;
+    }
+
+    private void OnFixedGridResizeStarted(object sender, DragStartedEventArgs e)
+    {
+        if (ViewModel.IsFixedSize)
+        {
+            var columns = ViewModel.SizeMode.Columns;
+            var rows = ViewModel.SizeMode.Rows;
+            _fixedGridResizeStartWidth = columns * ViewModel.LayoutSettings.ItemSlotWidth;
+            _fixedGridResizeStartHeight = rows * ViewModel.LayoutSettings.ItemSlotHeight;
+        }
+        else
+        {
+            // 用 GridCanvasWidth/Height (实际内容尺寸) 当起点,而不是 IconList.ActualWidth (含虚拟滚动只是视口大小)
+            _fixedGridResizeStartWidth = Math.Max(1, ViewModel.GridCanvasWidth);
+            _fixedGridResizeStartHeight = Math.Max(1, ViewModel.GridCanvasHeight);
+        }
+        GetCursorPos(out _fixedGridResizeStartCursor);
+        e.Handled = true;
+    }
+
+    private void OnFixedGridResizeDelta(object sender, DragDeltaEventArgs e)
+    {
+        if (!GetCursorPos(out var currentCursor))
+        {
+            return;
+        }
+
+        var horizontalDelta = currentCursor.X - _fixedGridResizeStartCursor.X;
+        var verticalDelta = currentCursor.Y - _fixedGridResizeStartCursor.Y;
+        var dpi = VisualTreeHelper.GetDpi(this);
+        ViewModel.ResizeFixedGrid(
+            _fixedGridResizeStartWidth + (horizontalDelta / Math.Max(0.1, dpi.DpiScaleX)),
+            _fixedGridResizeStartHeight + (verticalDelta / Math.Max(0.1, dpi.DpiScaleY)));
+        e.Handled = true;
+    }
+
+    private async void OnFixedGridResizeCompleted(object sender, DragCompletedEventArgs e)
+    {
+        if (e.Canceled)
+        {
+            // 拖拽被取消：回滚到拖拽前的 m×n（按当前 SizeMode）。
+            ViewModel.ResizeFixedGrid(
+                _fixedGridResizeStartWidth,
+                _fixedGridResizeStartHeight);
+            e.Handled = true;
+            return;
+        }
+
+        try
+        {
+            await ViewModel.SaveSizeModeAsync();
+        }
+        catch (Exception exception)
+        {
+            ViewModel.ResizeFixedGrid(
+                _fixedGridResizeStartWidth,
+                _fixedGridResizeStartHeight);
+            _ = exception;
+        }
+
+        e.Handled = true;
+    }
+
+    private void OnMappingListHeightResizeStarted(object sender, DragStartedEventArgs e)
+    {
+        _mappingListHeightResizeStartHeight = ViewModel.MappingListHeight;
+        GetCursorPos(out _mappingListHeightResizeStartCursor);
+        e.Handled = true;
+    }
+
+    private void OnMappingListHeightResizeDelta(object sender, DragDeltaEventArgs e)
+    {
+        if (!GetCursorPos(out var currentCursor))
+        {
+            return;
+        }
+
+        var verticalDelta = currentCursor.Y - _mappingListHeightResizeStartCursor.Y;
+        var dpi = VisualTreeHelper.GetDpi(this);
+        ViewModel.ResizeMappingListHeight(
+            _mappingListHeightResizeStartHeight + (verticalDelta / Math.Max(0.1, dpi.DpiScaleY)));
+        e.Handled = true;
+    }
+
+    private async void OnMappingListHeightResizeCompleted(object sender, DragCompletedEventArgs e)
+    {
+        if (e.Canceled)
+        {
+            ViewModel.ResizeMappingListHeight(_mappingListHeightResizeStartHeight);
+            e.Handled = true;
+            return;
+        }
+
+        try
+        {
+            await ViewModel.SaveMappingListHeightAsync();
+        }
+        catch (Exception exception)
+        {
+            ViewModel.ResizeMappingListHeight(_mappingListHeightResizeStartHeight);
+            _ = exception;
+        }
+
         e.Handled = true;
     }
 

--- a/tests/WitchDrawer.App.Tests/BoxFreeResizeTests.cs
+++ b/tests/WitchDrawer.App.Tests/BoxFreeResizeTests.cs
@@ -1,0 +1,368 @@
+using System.IO;
+using WitchDrawer.App.ViewModels;
+using WitchDrawer.Core;
+using WitchDrawer.Core.Abstractions;
+using WitchDrawer.Core.Logging;
+using WitchDrawer.Core.Models;
+using WitchDrawer.Core.Services;
+using WitchDrawer.Core.Storage;
+
+namespace WitchDrawer.App.Tests;
+
+public sealed class BoxFreeResizeTests
+{
+    [Fact]
+    public void TodoBoxResize_ClampsToBoundsAndExposesBothDimensions()
+    {
+        var viewModel = CreateTodoBoxViewModel(out _);
+
+        // 默认值就是初始常量
+        Assert.Equal(310, viewModel.TodoBoxWidth);
+        Assert.Equal(320, viewModel.TodoBoxHeight);
+
+        // 越界 → 钳到边界
+        viewModel.ResizeTodoBox(width: 1000, height: 50);
+        Assert.Equal(720, viewModel.TodoBoxWidth);
+        Assert.Equal(160, viewModel.TodoBoxHeight);
+
+        viewModel.ResizeTodoBox(width: 0, height: 9999);
+        Assert.Equal(240, viewModel.TodoBoxWidth);
+        Assert.Equal(720, viewModel.TodoBoxHeight);
+
+        // 有限合法值原样接受
+        viewModel.ResizeTodoBox(width: 400, height: 280);
+        Assert.Equal(400, viewModel.TodoBoxWidth);
+        Assert.Equal(280, viewModel.TodoBoxHeight);
+    }
+
+    [Fact]
+    public void TodoBoxResize_IsIgnoredOnNonTodoBoxes()
+    {
+        var viewModel = CreateNormalBoxViewModel(out _);
+
+        viewModel.ResizeTodoBox(width: 600, height: 400);
+
+        // 非 todo 盒:属性保持默认初始值,操作被忽略
+        Assert.Equal(310, viewModel.TodoBoxWidth);
+        Assert.Equal(320, viewModel.TodoBoxHeight);
+    }
+
+    [Fact]
+    public async Task TodoBoxSize_RoundTripsThroughPersistedSetting()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var (drawerService, _) = await CreateDrawerServiceAsync(root);
+            var viewModel = CreateTodoBoxViewModel(out var box, drawerService);
+
+            viewModel.ResizeTodoBox(width: 420, height: 360);
+            await viewModel.SaveTodoBoxSizeAsync();
+
+            var reloaded = CreateTodoBoxViewModel(box, drawerService);
+            await reloaded.LoadTodoBoxSizeAsync();
+
+            Assert.Equal(420, reloaded.TodoBoxWidth);
+            Assert.Equal(360, reloaded.TodoBoxHeight);
+        }
+        finally
+        {
+            CleanupTempRoot(root);
+        }
+    }
+
+    [Fact]
+    public async Task MappingListHeight_ClampsWithinLayoutBoundsAndPersistsRoundTrip()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var (drawerService, _) = await CreateDrawerServiceAsync(root);
+            var viewModel = CreateMappingBoxViewModel(out var box, drawerService);
+
+            // LayoutSettings 默认 6x6 preset:
+            //   MappingListMinHeight = 58, MappingListMaxHeight = 294
+            // 无覆写时取 max(Min, Max) = 294
+            Assert.Equal(294, viewModel.MappingListHeight);
+
+            viewModel.ResizeMappingListHeight(120); // 120 = 5 * 24 → 吸附后仍是 120
+            Assert.Equal(120, viewModel.MappingListHeight);
+
+            viewModel.ResizeMappingListHeight(10);   // 低于 Min → 钳到 Min
+            Assert.Equal(58, viewModel.MappingListHeight);
+
+            viewModel.ResizeMappingListHeight(5000); // 高于 Max → 钳到 Max
+            Assert.Equal(294, viewModel.MappingListHeight);
+
+            // 保存 → 重新加载保留(192 = 8 * 24,正好是行高整数倍)
+            viewModel.ResizeMappingListHeight(180);
+            await viewModel.SaveMappingListHeightAsync();
+
+            var reloaded = CreateMappingBoxViewModel(box, drawerService);
+            await reloaded.LoadMappingListHeightAsync();
+
+            Assert.Equal(192, reloaded.MappingListHeight);
+        }
+        finally
+        {
+            CleanupTempRoot(root);
+        }
+    }
+
+    [Fact]
+    public void MappingListHeight_OverrideRevertsToLayoutMaxWhenCleared()
+    {
+        var viewModel = CreateMappingBoxViewModel(out _);
+
+        viewModel.ResizeMappingListHeight(150); // 吸附到 6 * 24 = 144
+        Assert.Equal(144, viewModel.MappingListHeight);
+
+        viewModel.ResizeMappingListHeight(294); // 等于 layout Max(288 吸附后) → 等同清空覆写
+        Assert.Equal(294, viewModel.MappingListHeight);
+    }
+
+    [Fact]
+    public void FixedGridResize_RoundsPixelDeltaToIntegerCellCounts()
+    {
+        var viewModel = CreateNormalBoxViewModel(out _);
+
+        // ResizeFixedGrid 在自适应模式下为 no-op,需要先切到固定模式
+        viewModel.ApplySizeMode(new BoxSizeModeState(true, 6, 6));
+
+        // 默认 6x6 preset:ItemSlotWidth=37, ItemSlotHeight=37
+        // 200/37 ≈ 5.4 → round → 5
+        viewModel.ResizeFixedGrid(widthDip: 200, heightDip: 200);
+        Assert.Equal(5, viewModel.SizeMode.Columns);
+        Assert.Equal(5, viewModel.SizeMode.Rows);
+        Assert.True(viewModel.IsFixedSize);
+    }
+
+    [Fact]
+    public void FixedGridResize_EnforcesOccupiedExtentAsLowerBound()
+    {
+        var viewModel = CreateNormalBoxViewModel(out _);
+
+        // 固定 2x2,Items.Count=0 → 占用 1x1,降不下
+        viewModel.ApplySizeMode(new BoxSizeModeState(true, 2, 2));
+        viewModel.ResizeFixedGrid(widthDip: 1, heightDip: 1);
+        Assert.Equal(1, viewModel.SizeMode.Columns);
+        Assert.Equal(1, viewModel.SizeMode.Rows);
+    }
+
+    [Fact]
+    public void FixedGridResize_NormalBoxAdaptive_AutoSwitchesToFixed()
+    {
+        var viewModel = CreateNormalBoxViewModel(out _);
+
+        Assert.False(viewModel.IsFixedSize);
+
+        // 默认 6x6 preset:ItemSlotWidth=37,500/37≈13.5→14
+        viewModel.ResizeFixedGrid(widthDip: 500, heightDip: 500);
+
+        // 角落 Thumb 现在始终可见,自适应状态下拖动会自动切到固定 m×n
+        Assert.True(viewModel.IsFixedSize);
+        Assert.Equal(14, viewModel.SizeMode.Columns);
+        Assert.Equal(14, viewModel.SizeMode.Rows);
+    }
+
+    [Fact]
+    public async Task FixedGridResize_PersistsViaSizeModeKeyAndReloads()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var (drawerService, _) = await CreateDrawerServiceAsync(root);
+            var first = CreateNormalBoxViewModel(out var box, drawerService);
+
+            // 进入固定模式,ResizeFixedGrid 才生效
+            first.ApplySizeMode(new BoxSizeModeState(true, 6, 6));
+
+            first.ResizeFixedGrid(widthDip: 400, heightDip: 250);
+            // 400/37 ≈ 10.8 → 11,250/37 ≈ 6.8 → 7
+            Assert.Equal(11, first.SizeMode.Columns);
+            Assert.Equal(7, first.SizeMode.Rows);
+
+            await first.SaveSizeModeAsync();
+
+            var reloaded = CreateNormalBoxViewModel(box, drawerService);
+            await reloaded.LoadSizeModeAsync();
+
+            Assert.Equal(new BoxSizeModeState(true, 11, 7), reloaded.SizeMode);
+        }
+        finally
+        {
+            CleanupTempRoot(root);
+        }
+    }
+
+    [Fact]
+    public void ShowFixedResizeHandle_OnlyTrueInFixedModeForSupportingBoxes()
+    {
+        var normal = CreateNormalBoxViewModel(out _);
+        var todo = CreateTodoBoxViewModel(out _);
+        var mapping = CreateMappingBoxViewModel(out _);
+
+        Assert.True(normal.ShowFixedResizeHandle); // 普通盒角落 Thumb 始终可见
+        normal.ApplySizeMode(new BoxSizeModeState(true, 4, 4));
+        Assert.True(normal.ShowFixedResizeHandle);
+
+        Assert.False(todo.ShowFixedResizeHandle); // todo 走 TodoBoxWidth/Height,不显示固定 m×n 拇指
+        Assert.True(mapping.ShowFixedResizeHandle); // 映射盒网格模式角落 Thumb 始终可见,允许自适应状态拖动自动切到固定
+    }
+
+    [Fact]
+    public void FixedGridResize_OnMappingGrid_AutoSwitchesFromAdaptiveToFixed()
+    {
+        var viewModel = CreateMappingBoxViewModel(out _);
+
+        Assert.False(viewModel.IsFixedSize); // 默认自适应
+        Assert.True(viewModel.ShowFixedResizeHandle); // 角落 Thumb 仍可见
+
+        // 默认 6x6 preset:ItemSlotWidth=37
+        // 250/37 ≈ 6.8 → 7
+        viewModel.ResizeFixedGrid(widthDip: 250, heightDip: 250);
+
+        Assert.True(viewModel.IsFixedSize); // 拖动后自动切到固定
+        Assert.Equal(7, viewModel.SizeMode.Columns);
+        Assert.Equal(7, viewModel.SizeMode.Rows);
+    }
+
+    private static DesktopBoxViewModel CreateTodoBoxViewModel(
+        out Box box,
+        DrawerService? drawerService = null)
+    {
+        box = new Box(
+            Guid.NewGuid(),
+            "待办收纳盒",
+            BoxType.Todo,
+            Path.Combine(Path.GetTempPath(), "WitchDrawerTests", Guid.NewGuid().ToString("N")),
+            0,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+        return CreateTodoBoxViewModel(box, drawerService);
+    }
+
+    private static DesktopBoxViewModel CreateTodoBoxViewModel(
+        Box box,
+        DrawerService? drawerService = null)
+    {
+        return new DesktopBoxViewModel(
+            box,
+            drawerService ?? new DrawerService(
+                new AppPaths(Path.Combine(Path.GetTempPath(), "WitchDrawerTests", Guid.NewGuid().ToString("N"))),
+                new DrawerRepository(Path.Combine(Path.GetTempPath(), "db.sqlite"))),
+            new TodoService(new DrawerRepository(Path.Combine(Path.GetTempPath(), "db.sqlite"))),
+            new NoOpFileLauncher(),
+            new RecordingLogger(),
+            BoxVisualStyle.Modern);
+    }
+
+    private static DesktopBoxViewModel CreateNormalBoxViewModel(
+        out Box box,
+        DrawerService? drawerService = null)
+    {
+        box = new Box(
+            Guid.NewGuid(),
+            "普通收纳盒",
+            BoxType.Normal,
+            Path.Combine(Path.GetTempPath(), "WitchDrawerTests", Guid.NewGuid().ToString("N")),
+            0,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+        return CreateNormalBoxViewModel(box, drawerService);
+    }
+
+    private static DesktopBoxViewModel CreateNormalBoxViewModel(
+        Box box,
+        DrawerService? drawerService = null)
+    {
+        return new DesktopBoxViewModel(
+            box,
+            drawerService ?? new DrawerService(
+                new AppPaths(Path.Combine(Path.GetTempPath(), "WitchDrawerTests", Guid.NewGuid().ToString("N"))),
+                new DrawerRepository(Path.Combine(Path.GetTempPath(), "db.sqlite"))),
+            new TodoService(new DrawerRepository(Path.Combine(Path.GetTempPath(), "db.sqlite"))),
+            new NoOpFileLauncher(),
+            new RecordingLogger(),
+            BoxVisualStyle.Modern);
+    }
+
+    private static DesktopBoxViewModel CreateMappingBoxViewModel(
+        out Box box,
+        DrawerService? drawerService = null)
+    {
+        box = new Box(
+            Guid.NewGuid(),
+            "映射收纳盒",
+            BoxType.Mapping,
+            Path.Combine(Path.GetTempPath(), "WitchDrawerTests", Guid.NewGuid().ToString("N")),
+            0,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+        return CreateMappingBoxViewModel(box, drawerService);
+    }
+
+    private static DesktopBoxViewModel CreateMappingBoxViewModel(
+        Box box,
+        DrawerService? drawerService = null)
+    {
+        return new DesktopBoxViewModel(
+            box,
+            drawerService ?? new DrawerService(
+                new AppPaths(Path.Combine(Path.GetTempPath(), "WitchDrawerTests", Guid.NewGuid().ToString("N"))),
+                new DrawerRepository(Path.Combine(Path.GetTempPath(), "db.sqlite"))),
+            new TodoService(new DrawerRepository(Path.Combine(Path.GetTempPath(), "db.sqlite"))),
+            new NoOpFileLauncher(),
+            new RecordingLogger(),
+            BoxVisualStyle.Modern);
+    }
+
+    private static string CreateTempRoot() =>
+        Path.Combine(Path.GetTempPath(), "WitchDrawerTests", Guid.NewGuid().ToString("N"));
+
+    private static async Task<(DrawerService Service, DrawerRepository Repository)> CreateDrawerServiceAsync(
+        string root)
+    {
+        var paths = new AppPaths(root);
+        var repository = new DrawerRepository(paths.DatabasePath);
+        var drawerService = new DrawerService(paths, repository);
+        await drawerService.InitializeAsync();
+        return (drawerService, repository);
+    }
+
+    private static void CleanupTempRoot(string root)
+    {
+        for (var attempt = 0; attempt < 10; attempt++)
+        {
+            try
+            {
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, recursive: true);
+                }
+
+                return;
+            }
+            catch (IOException) when (attempt < 9)
+            {
+                Thread.Sleep(100);
+            }
+        }
+    }
+
+    private sealed class NoOpFileLauncher : IFileLauncher
+    {
+        public Task OpenAsync(string path, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class RecordingLogger : IAppLogger
+    {
+        public void Info(string message)
+        {
+        }
+
+        public void Error(Exception exception, string message)
+        {
+        }
+    }
+}

--- a/tests/WitchDrawer.App.Tests/BoxSizeSettingsTests.cs
+++ b/tests/WitchDrawer.App.Tests/BoxSizeSettingsTests.cs
@@ -153,10 +153,11 @@ public sealed class BoxSizeSettingsTests
         try
         {
             var (drawerService, repository) = await CreateDrawerServiceAsync(root);
+            // 抽屉 / 待办这类非网格盒不应支持固定尺寸;映射盒现已支持固定 m×n,不再属于此用例。
             var box = new Box(
                 Guid.NewGuid(),
-                "映射收纳盒",
-                BoxType.Mapping,
+                "抽屉收纳盒",
+                BoxType.Drawer,
                 null,
                 0,
                 DateTimeOffset.UtcNow,


### PR DESCRIPTION
- 普通 / 像素 / 映射盒(网格模式): 右下角斜箭头 Thumb, 按图标格 (ItemSlotWidth/Height=37) 吸附切换 m×n,任何模式下都可见; 自适应状态拖动可自动切到固定 m×n
- 待办盒: 右下角斜箭头 Thumb, 自由像素拖动 (240×160 ~ 720×720)
- 映射盒(列表模式): 底部 Thumb 按行高 (MappingListRowHeight=24) 吸附上下拖, 右侧 Thumb 自由左右拖 (180 ~ 720)
- 映射盒: 设置面板新增 "显示文件名" 开关 (沿用已有  SupportsFileNameVisibility / ToggleFileNameVisibility 机制)