### PR TITLE
chore(license): 明确非商业许可 —— 代码改用 PolyForm Noncommercial 1.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,83 @@
+# PolyForm Noncommercial License 1.0.0
+
+Copyright (c) 2026 Thewitchcat
+WitchDrawer - https://github.com/3yearsZhuang/WitchDrawer
+
+Required Notice: Copyright 2026 Thewitchcat (WitchDrawer - https://github.com/3yearsZhuang/WitchDrawer)
+
+Scope: this license applies to the software source code, build scripts, and
+configuration files distributed in this repository. Documentation and media
+assets are licensed separately under CC BY-NC-SA 4.0 - see the LICENSE-DOCS
+file.
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.  However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software.  Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice.  Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/LICENSE-DOCS
+++ b/LICENSE-DOCS
@@ -1,0 +1,77 @@
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+(CC BY-NC-SA 4.0)
+Copyright (c) 2026 Thewitchcat
+
+WitchDrawer - https://github.com/3yearsZhuang/WitchDrawer
+
+--------------------------------------------------------------------------------
+
+SCOPE
+-----
+
+This license applies to the documentation and media assets of the WitchDrawer
+project, specifically:
+
+  - Documentation: all Markdown/plain-text documentation under `docs/`
+    (e.g. `docs/PROJECT_PLAN.md`, `docs/ARCHITECTURE.md`,
+    `docs/SELECTION_FRAME_DRIFT_REPORT.md`).
+  - Images and other media under `docs/images/`
+    (e.g. `docs/images/witchdrawer-desktop-showcase.png`).
+  - Application artwork, icons, and bundled media under
+    `src/WitchDrawer.App/Assets/` (e.g. `app.png`, `app.ico`).
+  - Any other non-code asset distributed with this repository that is not part
+    of the software source code.
+
+The software source code is NOT covered by this license. Source code, build
+scripts, and configuration (including but not limited to `src/**/*.cs`,
+`src/**/*.xaml`, `tests/`, `tools/`, `installer/`, `*.sln`, `*.props`, and
+`*.ps1`) is licensed under the PolyForm Noncommercial License 1.0.0 - see the
+`LICENSE` file.
+
+Both licenses are noncommercial: no commercial use of this project - whether of
+its code or of its documentation and assets - is permitted.
+
+--------------------------------------------------------------------------------
+
+LICENSE TERMS
+-------------
+
+You are free to:
+
+  - Share - copy and redistribute the material in any medium or format.
+  - Adapt - remix, transform, and build upon the material.
+
+Under the following terms:
+
+  - Attribution (BY) - You must give appropriate credit to the original author
+    Thewitchcat, provide a link to the license, and indicate if changes were
+    made. You may do so in any reasonable manner, but not in any way that
+    suggests the licensor endorses you or your use.
+
+  - NonCommercial (NC) - You may not use the material for commercial purposes.
+
+  - ShareAlike (SA) - If you remix, transform, or build upon the material, you
+    must distribute your contributions under the same license as the original.
+
+  - No additional restrictions - You may not apply legal terms or technological
+    measures that legally restrict others from doing anything the license
+    permits.
+
+--------------------------------------------------------------------------------
+
+NOTICES
+-------
+
+You do not have to comply with the license for elements of the material in the
+public domain or where your use is permitted by an applicable exception or
+limitation.
+
+No warranties are given. The license may not give you all of the permissions
+necessary for your intended use. Other rights such as publicity, privacy, or
+moral rights may limit how you use the material.
+
+Full legal code:
+  https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+
+Human-readable summary:
+  https://creativecommons.org/licenses/by-nc-sa/4.0/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/version-1.3.11-blue" alt="Version" />
-  <img src="https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-green" alt="License" />
+  <img src="https://img.shields.io/badge/license-PolyForm%20Noncommercial%201.0.0-orange" alt="License" />
+  <img src="https://img.shields.io/badge/docs%20%26%20assets-CC%20BY--NC--SA%204.0-lightgrey" alt="Docs & Assets License" />
   <img src="https://img.shields.io/badge/.NET-10.0-purple" alt=".NET" />
   <img src="https://img.shields.io/badge/platform-Windows-blue" alt="Platform" />
 </p>
@@ -150,7 +151,31 @@ dotnet test WitchDrawer.sln
 
 ## 开源协议
 
-本项目采用 **CC BY-NC-SA 4.0** 协议开源。
+本项目采用**双许可**，两者均为**非商业许可**：**禁止任何商业用途**。源代码与文档/素材分别授权。
+
+### 源代码 —— PolyForm Noncommercial License 1.0.0
+
+`src/`、`tests/`、`tools/`、`installer/` 下的源代码、构建脚本与配置文件采用 **PolyForm Noncommercial License 1.0.0** 授权，完整条款见 [LICENSE](LICENSE)。
+
+**允许**（非商业目的）：
+
+- 个人使用：研究、实验、测试、个人学习、私人娱乐、爱好项目、宗教活动
+- 非商业组织使用：慈善组织、教育机构、公共研究机构、公共安全或卫生机构、环保组织、政府机构（不论资金来源）
+- 修改、创作新作品，以及分发副本（须随附许可条款与 `Required Notice:` 声明）
+
+**禁止**：
+
+- 任何商业用途
+
+**其他要点**：
+
+- 附带专利授权；若你书面主张本项目侵犯专利，则专利授权立即终止
+- 违规后收到书面通知起 32 天内完全纠正并采取补救措施，授权可继续；否则立即终止
+- 软件按「现状」提供，不附带任何担保
+
+### 文档与素材 —— CC BY-NC-SA 4.0
+
+`docs/` 下的文档与图片，以及 `src/WitchDrawer.App/Assets/` 下的图标、美术等媒体素材，采用 **CC BY-NC-SA 4.0** 授权，完整说明见 [LICENSE-DOCS](LICENSE-DOCS)。
 
 - **BY（署名）**：二次修改必须注明原作者 Thewitchcat
 - **NC（非商用）**：禁止商业使用


### PR DESCRIPTION
## 变更目的

明确本项目**禁止任何商业用途**，并把源代码与文档/素材的授权拆分。

## 变更内容

变更前：README 仅有一句「本项目采用 CC BY-NC-SA 4.0 协议开源」，仓库**没有 LICENSE 文件**。
变更后：采用双许可。

| 范围 | 许可 | 文件 |
|---|---|---|
| 源代码、构建脚本、配置 | PolyForm Noncommercial License 1.0.0 | `LICENSE`（新增） |
| 文档、图片、图标、美术素材 | CC BY-NC-SA 4.0 | `LICENSE-DOCS`（新增） |

- `LICENSE`：PolyForm Noncommercial 1.0.0 官方全文；顶部补齐 licensor 标识与 `Required Notice:` 行（该许可的 Notices 条款引用它）。
- `LICENSE-DOCS`：CC BY-NC-SA 4.0；明确 scope 为 `docs/**`、`docs/images/**`、`src/WitchDrawer.App/Assets/**`，并反向声明源代码不在本许可范围内。
- `README.md`：许可徽章更新为 PolyForm Noncommercial + Docs & Assets 两枚；「开源协议」章节改写为双许可结构（允许 / 禁止 / 其他要点）。

## 影响面

- **未改动任何代码**（`src/`、`tests/`、`tools/`、`installer/` 无 diff），无需重新构建或测试。
- 无版本号变更（仍为 1.3.11）。
- 许可变更自合并起对后续所有使用与分发生效。

## 需要维护者确认的点

1. 是否同意项目整体为**非商业许可**（代码 + 文档/素材）。
2. PolyForm Noncommercial 1.0.0 **不是 copyleft**，不要求衍生作品沿用同协议；原 CC BY-NC-SA 的 **SA（相同方式共享）** 在代码部分不再保留。若希望保留 ShareAlike，需要另行讨论。
3. 如希望连「修改 / 再分发」也一并禁止，可改用 **PolyForm Strict 1.0.0**。

## 检查

- [x] 无残留旧许可引用（已检索 `hippocratic` / `HL3` / `firstdonoharm` / `copyleft`，结果为空）
- [x] `LICENSE` 与 `LICENSE-DOCS` 交叉引用一致
- [x] README 徽章与正文表述一致
- [x] 未改动代码，无需 `dotnet build` / `dotnet test`
